### PR TITLE
feat: add TUI mode and improve token/retry resilience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,12 +80,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -101,16 +125,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -123,6 +189,15 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -177,7 +252,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -193,6 +268,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +292,15 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -279,6 +377,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,10 +395,104 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.13.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "futures-core",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "deranged"
@@ -307,7 +508,39 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -318,7 +551,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -329,6 +562,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -353,10 +592,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -367,6 +654,18 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -406,7 +705,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -438,6 +737,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,9 +768,31 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -469,12 +800,23 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -657,6 +999,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,7 +1032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -701,18 +1049,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "ipatool-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "crossterm",
+ "futures-util",
  "ipatool-core",
+ "ratatui",
  "rpassword",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "tui-input",
 ]
 
 [[package]]
@@ -731,7 +1106,7 @@ dependencies = [
  "reqwest_cookie_store",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -751,6 +1126,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +1149,17 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -783,6 +1178,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,14 +1196,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "linux-keyutils"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -817,10 +1239,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "lru-slab"
@@ -854,6 +1294,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +1307,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -879,6 +1331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -889,11 +1342,21 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -910,6 +1373,35 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "number_prefix"
@@ -930,10 +1422,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "phf"
@@ -942,6 +1533,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
  "phf_shared",
 ]
 
@@ -965,7 +1566,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1074,7 +1675,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1095,7 +1696,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1129,6 +1730,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1172,6 +1779,128 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termina",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.0",
+ "compact_str",
+ "critical-section",
+ "hashbrown 0.17.1",
+ "itertools",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termina"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1288,6 +2017,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,12 +2086,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -1353,7 +2110,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -1369,6 +2126,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1397,7 +2160,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1426,6 +2189,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,6 +2213,27 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -1491,16 +2286,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1530,7 +2363,92 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.13.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -1539,7 +2457,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1550,7 +2479,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1569,7 +2498,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -1641,7 +2572,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1663,6 +2594,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -1688,7 +2620,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -1731,7 +2663,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1780,10 +2712,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tui-input"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd014a652e31cf25ea68d11b10a7b09549863449b19387505c9933f11eb05fa"
+dependencies = [
+ "ratatui",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
 
 [[package]]
 name = "unicode-width"
@@ -1822,6 +2794,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,6 +2816,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "want"
@@ -1899,7 +2892,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -1952,6 +2945,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -2178,7 +3243,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -2199,7 +3264,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2219,7 +3284,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -2259,7 +3324,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2275,7 +3340,7 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "thiserror",
+ "thiserror 2.0.18",
  "zopfli",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ serde_json = "1"
 thiserror = "2"
 anyhow = "1"
 tracing = "0.1"
+ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
+crossterm = { version = "0.29", features = ["event-stream"] }
+tui-input = "0.15"
+tokio-util = { version = "0.7", features = ["rt"] }

--- a/crates/ipatool-cli/Cargo.toml
+++ b/crates/ipatool-cli/Cargo.toml
@@ -19,3 +19,8 @@ tracing.workspace = true
 clap = { version = "4", features = ["derive", "env"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rpassword = "7"
+ratatui.workspace = true
+crossterm.workspace = true
+tui-input.workspace = true
+futures-util = "0.3"
+tokio-util.workspace = true

--- a/crates/ipatool-cli/src/commands/auth.rs
+++ b/crates/ipatool-cli/src/commands/auth.rs
@@ -30,10 +30,11 @@ pub async fn login(
 
     tracing::info!(url = %auth_url, "using auth endpoint");
 
-    let account = api::auth::login(client, email, &password, auth_code, &auth_url)
+    let mut account = api::auth::login(client, email, &password, auth_code, &auth_url)
         .await
         .context("login failed")?;
 
+    account.password = Some(password);
     credential::store_account(&account).context("failed to store credentials")?;
 
     client.set_account(account.clone());

--- a/crates/ipatool-cli/src/commands/download.rs
+++ b/crates/ipatool-cli/src/commands/download.rs
@@ -44,6 +44,8 @@ pub async fn download(
 
     eprintln!("Requesting download info...");
     let mut item = None;
+    let mut purchase_attempted = false;
+    let mut last_download_error = None;
 
     for attempt in 0..MAX_ATTEMPTS {
         match api::download::get_download_info(client, resolved_app_id, &account, version_id).await
@@ -52,23 +54,18 @@ pub async fn download(
                 item = Some(i);
                 break;
             }
-            Err(e) if e.is_license_not_found() && do_purchase => {
+            Err(e) if e.is_license_not_found() && do_purchase && !purchase_attempted => {
+                last_download_error = Some(e.to_string());
                 eprintln!("License not found, purchasing...");
-                match api::purchase::purchase(client, resolved_app_id, &account).await {
-                    Ok(()) => eprintln!("Purchase successful"),
-                    Err(pe) if pe.is_token_expired() => {
-                        account = reauth_or_fail(client, &account).await?;
-                        api::purchase::purchase(client, resolved_app_id, &account)
-                            .await
-                            .context("purchase failed after re-auth")?;
-                    }
-                    Err(pe) if !pe.is_license_already_exists() => {
-                        return Err(pe).context("purchase failed");
-                    }
-                    Err(_) => {}
-                }
+                purchase_for_download(client, resolved_app_id, &mut account).await?;
+                purchase_attempted = true;
+                eprintln!("Purchase successful");
+            }
+            Err(e) if e.is_license_not_found() && do_purchase => {
+                return Err(e).context("license not found after purchase");
             }
             Err(e) if e.is_token_expired() && attempt + 1 < MAX_ATTEMPTS => {
+                last_download_error = Some(e.to_string());
                 eprintln!(
                     "Token expired, re-authenticating (attempt {})...",
                     attempt + 1
@@ -84,7 +81,12 @@ pub async fn download(
         }
     }
 
-    let item = item.context("failed to get download info after retries")?;
+    let item = item.with_context(|| {
+        last_download_error.map_or_else(
+            || "failed to get download info after retries".to_string(),
+            |e| format!("failed to get download info after retries: {e}"),
+        )
+    })?;
 
     let version = item
         .metadata
@@ -109,4 +111,22 @@ pub async fn download(
 
     eprintln!("Saved to {}", dest.display());
     Ok(())
+}
+
+async fn purchase_for_download(
+    client: &AppleClient,
+    app_id: i64,
+    account: &mut Account,
+) -> Result<()> {
+    match api::purchase::purchase(client, app_id, account).await {
+        Ok(()) => Ok(()),
+        Err(e) if e.is_token_expired() => {
+            *account = reauth_or_fail(client, account).await?;
+            api::purchase::purchase(client, app_id, account)
+                .await
+                .context("purchase failed after re-auth")
+        }
+        Err(e) if e.is_license_already_exists() => Ok(()),
+        Err(e) => Err(e).context("purchase failed"),
+    }
 }

--- a/crates/ipatool-cli/src/commands/download.rs
+++ b/crates/ipatool-cli/src/commands/download.rs
@@ -10,6 +10,10 @@ use ipatool_core::ipa::patch;
 use ipatool_core::model::storefront::country_code_from_store_front;
 use ipatool_core::model::{Account, Platform};
 
+use super::reauth_or_fail;
+
+const MAX_ATTEMPTS: u32 = 3;
+
 pub async fn download(
     client: &AppleClient,
     bundle_identifier: Option<&str>,
@@ -20,6 +24,7 @@ pub async fn download(
     platform: Platform,
     account: &Account,
 ) -> Result<()> {
+    let mut account = account.clone();
     let country = country_code_from_store_front(&account.store_front).unwrap_or("US");
 
     let resolved_app_id = match app_id {
@@ -37,17 +42,49 @@ pub async fn download(
         }
     };
 
-    if do_purchase {
-        eprintln!("Obtaining license...");
-        api::purchase::purchase(client, resolved_app_id, account)
-            .await
-            .context("purchase failed")?;
+    eprintln!("Requesting download info...");
+    let mut item = None;
+
+    for attempt in 0..MAX_ATTEMPTS {
+        match api::download::get_download_info(client, resolved_app_id, &account, version_id).await
+        {
+            Ok(i) => {
+                item = Some(i);
+                break;
+            }
+            Err(e) if e.is_license_not_found() && do_purchase => {
+                eprintln!("License not found, purchasing...");
+                match api::purchase::purchase(client, resolved_app_id, &account).await {
+                    Ok(()) => eprintln!("Purchase successful"),
+                    Err(pe) if pe.is_token_expired() => {
+                        account = reauth_or_fail(client, &account).await?;
+                        api::purchase::purchase(client, resolved_app_id, &account)
+                            .await
+                            .context("purchase failed after re-auth")?;
+                    }
+                    Err(pe) if !pe.is_license_already_exists() => {
+                        return Err(pe).context("purchase failed");
+                    }
+                    Err(_) => {}
+                }
+            }
+            Err(e) if e.is_token_expired() && attempt + 1 < MAX_ATTEMPTS => {
+                eprintln!(
+                    "Token expired, re-authenticating (attempt {})...",
+                    attempt + 1
+                );
+                account = reauth_or_fail(client, &account).await?;
+            }
+            Err(e) if e.is_license_not_found() => {
+                return Err(e).context("license not found (use --purchase to acquire)");
+            }
+            Err(e) => {
+                return Err(e).context("failed to get download info");
+            }
+        }
     }
 
-    eprintln!("Requesting download info...");
-    let item = api::download::get_download_info(client, resolved_app_id, account, version_id)
-        .await
-        .context("failed to get download info")?;
+    let item = item.context("failed to get download info after retries")?;
 
     let version = item
         .metadata

--- a/crates/ipatool-cli/src/commands/mod.rs
+++ b/crates/ipatool-cli/src/commands/mod.rs
@@ -3,3 +3,19 @@ pub mod download;
 pub mod purchase;
 pub mod search;
 pub mod version;
+
+use anyhow::{Context, Result};
+
+use ipatool_core::client::AppleClient;
+use ipatool_core::model::Account;
+
+pub async fn reauth_or_fail(client: &AppleClient, account: &Account) -> Result<Account> {
+    eprintln!("Token expired, re-authenticating...");
+    let new_account = ipatool_core::api::reauth::reauthenticate(client, account)
+        .await
+        .context("re-authentication failed")?;
+    ipatool_core::credential::store_account(&new_account)
+        .context("failed to store refreshed credentials")?;
+    eprintln!("Re-authenticated as {}", new_account.name);
+    Ok(new_account)
+}

--- a/crates/ipatool-cli/src/commands/purchase.rs
+++ b/crates/ipatool-cli/src/commands/purchase.rs
@@ -20,9 +20,16 @@ pub async fn purchase(
 
     eprintln!("Purchasing {} ({})", app.name, app.id);
 
-    api::purchase::purchase(client, app.id, account)
-        .await
-        .context("purchase failed")?;
+    match api::purchase::purchase(client, app.id, account).await {
+        Ok(()) => {}
+        Err(e) if e.is_token_expired() => {
+            let new_account = super::reauth_or_fail(client, account).await?;
+            api::purchase::purchase(client, app.id, &new_account)
+                .await
+                .context("purchase failed after re-auth")?;
+        }
+        Err(e) => return Err(e).context("purchase failed"),
+    }
 
     eprintln!("Done");
     Ok(())

--- a/crates/ipatool-cli/src/main.rs
+++ b/crates/ipatool-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod output;
+mod tui;
 
 use std::path::PathBuf;
 
@@ -21,7 +22,7 @@ use output::OutputFormat;
 )]
 struct Cli {
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
     #[arg(long, global = true, default_value = "text")]
     format: OutputFormat,
     #[arg(long, global = true)]
@@ -118,16 +119,20 @@ async fn main() -> Result<()> {
         .with_target(false)
         .init();
 
+    let Some(command) = cli.command else {
+        return tui::run().await;
+    };
+
     let guid_str = guid::generate_guid().context("failed to generate GUID")?;
 
-    let data_dir = dirs();
+    let data_dir = data_dir();
     std::fs::create_dir_all(&data_dir).ok();
     let cookie_path = data_dir.join("cookies.json");
 
     let mut client = ipatool_core::client::AppleClient::new(guid_str, Some(&cookie_path))
         .context("failed to create client")?;
 
-    match cli.command {
+    match command {
         Commands::Auth { action } => match action {
             AuthAction::Login {
                 email,
@@ -223,7 +228,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn dirs() -> std::path::PathBuf {
+pub(crate) fn data_dir() -> std::path::PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
     std::path::PathBuf::from(home).join(".ipatool")
 }

--- a/crates/ipatool-cli/src/tui/action.rs
+++ b/crates/ipatool-cli/src/tui/action.rs
@@ -1,0 +1,52 @@
+use ipatool_core::model::{Account, App};
+
+use super::app::{ActiveTab, DownloadStage};
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum Action {
+    Quit,
+    Tick,
+    Render,
+
+    SwitchTab(ActiveTab),
+
+    SubmitSearch,
+    SearchResults(Vec<App>),
+    SearchError(String),
+
+    StartDownload {
+        bundle_id: String,
+        app_name: String,
+        app_id: i64,
+    },
+    DownloadProgress {
+        id: usize,
+        stage: DownloadStage,
+        progress: u64,
+        total: u64,
+    },
+    DownloadComplete(usize),
+    DownloadError {
+        id: usize,
+        error: String,
+    },
+    CancelDownload(usize),
+    DownloadCancelled(usize),
+    ClearFinishedDownloads,
+
+    SubmitLogin,
+    LoginNeedsAuthCode,
+    LoginSuccess(Account),
+    LoginError(String),
+    Logout,
+    AccountRefreshed(Account),
+
+    Purchase(i64, String),
+    PurchaseSuccess(String),
+    PurchaseError(String),
+
+    ShowPopup(String),
+    ClosePopup,
+    StatusMessage(String),
+}

--- a/crates/ipatool-cli/src/tui/app.rs
+++ b/crates/ipatool-cli/src/tui/app.rs
@@ -1,0 +1,200 @@
+use std::sync::Arc;
+
+use ratatui::widgets::{ListState, TableState};
+use tokio::sync::{Mutex, Semaphore};
+use tokio::sync::mpsc::UnboundedSender;
+use tokio_util::sync::CancellationToken;
+use tui_input::Input;
+
+use ipatool_core::client::AppleClient;
+use ipatool_core::model::storefront::country_code_from_store_front;
+use ipatool_core::model::{Account, App, Platform};
+
+use super::action::Action;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActiveTab {
+    Search,
+    Library,
+    Downloads,
+    Account,
+}
+
+impl ActiveTab {
+    pub const ALL: [ActiveTab; 4] = [
+        ActiveTab::Search,
+        ActiveTab::Library,
+        ActiveTab::Downloads,
+        ActiveTab::Account,
+    ];
+
+    pub fn title(&self) -> &'static str {
+        match self {
+            Self::Search => "Search",
+            Self::Library => "Library",
+            Self::Downloads => "Downloads",
+            Self::Account => "Account",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InputMode {
+    Normal,
+    SearchInput,
+    LoginEmail,
+    LoginPassword,
+    LoginAuthCode,
+    Popup(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DownloadStage {
+    Queued,
+    Purchasing,
+    Downloading,
+    Patching,
+    Complete,
+    Failed,
+    Cancelled,
+}
+
+impl std::fmt::Display for DownloadStage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Queued => write!(f, "Queued"),
+            Self::Purchasing => write!(f, "Purchasing"),
+            Self::Downloading => write!(f, "Downloading"),
+            Self::Patching => write!(f, "Patching"),
+            Self::Complete => write!(f, "Complete"),
+            Self::Failed => write!(f, "Failed"),
+            Self::Cancelled => write!(f, "Cancelled"),
+        }
+    }
+}
+
+pub struct DownloadTask {
+    pub id: usize,
+    pub app_name: String,
+    pub stage: DownloadStage,
+    pub progress: u64,
+    pub total: u64,
+    pub error: Option<String>,
+    pub cancel_token: CancellationToken,
+}
+
+pub struct App_ {
+    pub active_tab: ActiveTab,
+    pub input_mode: InputMode,
+    pub should_quit: bool,
+    pub action_tx: UnboundedSender<Action>,
+
+    pub search_input: Input,
+    pub search_results: Vec<App>,
+    pub search_table_state: TableState,
+    pub search_platform: Platform,
+    pub search_country: String,
+    pub is_loading: bool,
+    pub selected_detail: Option<App>,
+
+    pub downloads: Vec<DownloadTask>,
+    pub download_list_state: ListState,
+    pub download_semaphore: Arc<Semaphore>,
+    pub next_download_id: usize,
+
+    pub account: Option<Account>,
+    pub login_email: Input,
+    pub login_password: String,
+    pub login_auth_code: Input,
+    pub login_needs_auth_code: bool,
+    pub login_error: Option<String>,
+
+    pub client: Arc<Mutex<AppleClient>>,
+
+    pub status_message: String,
+}
+
+impl App_ {
+    pub fn new(client: AppleClient, action_tx: UnboundedSender<Action>) -> Self {
+        let account = ipatool_core::credential::load_account().ok().flatten();
+
+        let search_country = account
+            .as_ref()
+            .and_then(|a| country_code_from_store_front(&a.store_front))
+            .unwrap_or("US")
+            .to_string();
+
+        let client = {
+            let mut c = client;
+            if let Some(ref acc) = account {
+                c.set_account(acc.clone());
+            }
+            Arc::new(Mutex::new(c))
+        };
+
+        Self {
+            active_tab: ActiveTab::Search,
+            input_mode: InputMode::Normal,
+            should_quit: false,
+            action_tx,
+
+            search_input: Input::default(),
+            search_results: Vec::new(),
+            search_table_state: TableState::default(),
+            search_platform: Platform::IPhone,
+            search_country,
+            is_loading: false,
+            selected_detail: None,
+
+            downloads: Vec::new(),
+            download_list_state: ListState::default(),
+            download_semaphore: Arc::new(Semaphore::new(3)),
+            next_download_id: 0,
+
+            account,
+            login_email: Input::default(),
+            login_password: String::new(),
+            login_auth_code: Input::default(),
+            login_needs_auth_code: false,
+            login_error: None,
+
+            client,
+
+            status_message: String::new(),
+        }
+    }
+
+    pub fn selected_app(&self) -> Option<&App> {
+        let idx = self.search_table_state.selected()?;
+        self.search_results.get(idx)
+    }
+
+    pub fn update_selected_detail(&mut self) {
+        self.selected_detail = self.selected_app().cloned();
+    }
+
+    pub fn download_by_id(&self, id: usize) -> Option<&DownloadTask> {
+        self.downloads.iter().find(|d| d.id == id)
+    }
+
+    pub fn download_by_id_mut(&mut self, id: usize) -> Option<&mut DownloadTask> {
+        self.downloads.iter_mut().find(|d| d.id == id)
+    }
+
+    pub fn clear_finished_downloads(&mut self) {
+        self.downloads.retain(|d| {
+            !matches!(
+                d.stage,
+                DownloadStage::Complete | DownloadStage::Failed | DownloadStage::Cancelled
+            )
+        });
+        if self.downloads.is_empty() {
+            self.download_list_state.select(None);
+        } else if let Some(sel) = self.download_list_state.selected() {
+            if sel >= self.downloads.len() {
+                self.download_list_state
+                    .select(Some(self.downloads.len() - 1));
+            }
+        }
+    }
+}

--- a/crates/ipatool-cli/src/tui/app.rs
+++ b/crates/ipatool-cli/src/tui/app.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use ratatui::widgets::{ListState, TableState};
-use tokio::sync::{Mutex, Semaphore};
 use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::{Mutex, Semaphore};
 use tokio_util::sync::CancellationToken;
 use tui_input::Input;
 
@@ -190,11 +190,11 @@ impl App_ {
         });
         if self.downloads.is_empty() {
             self.download_list_state.select(None);
-        } else if let Some(sel) = self.download_list_state.selected() {
-            if sel >= self.downloads.len() {
-                self.download_list_state
-                    .select(Some(self.downloads.len() - 1));
-            }
+        } else if let Some(sel) = self.download_list_state.selected()
+            && sel >= self.downloads.len()
+        {
+            self.download_list_state
+                .select(Some(self.downloads.len() - 1));
         }
     }
 }

--- a/crates/ipatool-cli/src/tui/event.rs
+++ b/crates/ipatool-cli/src/tui/event.rs
@@ -1,0 +1,74 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use crossterm::event::{Event as CEvent, EventStream};
+use futures_util::StreamExt;
+use tokio::sync::mpsc;
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum Event {
+    Key(crossterm::event::KeyEvent),
+    Tick,
+    Render,
+    Resize(u16, u16),
+}
+
+pub struct EventHandler {
+    rx: mpsc::UnboundedReceiver<Event>,
+}
+
+impl EventHandler {
+    pub fn new() -> Self {
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        let tick_rate = Duration::from_millis(250);
+        let render_rate = Duration::from_millis(33);
+
+        tokio::spawn(async move {
+            let mut reader = EventStream::new();
+            let mut tick_interval = tokio::time::interval(tick_rate);
+            let mut render_interval = tokio::time::interval(render_rate);
+
+            loop {
+                tokio::select! {
+                    maybe_event = reader.next() => {
+                        match maybe_event {
+                            Some(Ok(CEvent::Key(key))) => {
+                                if tx.send(Event::Key(key)).is_err() {
+                                    break;
+                                }
+                            }
+                            Some(Ok(CEvent::Resize(w, h))) => {
+                                if tx.send(Event::Resize(w, h)).is_err() {
+                                    break;
+                                }
+                            }
+                            Some(Err(_)) | None => break,
+                            _ => {}
+                        }
+                    }
+                    _ = tick_interval.tick() => {
+                        if tx.send(Event::Tick).is_err() {
+                            break;
+                        }
+                    }
+                    _ = render_interval.tick() => {
+                        if tx.send(Event::Render).is_err() {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        Self { rx }
+    }
+
+    pub async fn next(&mut self) -> Result<Event> {
+        self.rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("event channel closed"))
+    }
+}

--- a/crates/ipatool-cli/src/tui/handler.rs
+++ b/crates/ipatool-cli/src/tui/handler.rs
@@ -1,0 +1,264 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use tui_input::backend::crossterm::EventHandler;
+
+use super::action::Action;
+use super::app::{ActiveTab, App_, InputMode};
+
+pub fn handle_key(app: &mut App_, key: KeyEvent) {
+    if let InputMode::Popup(_) = &app.input_mode {
+        match key.code {
+            KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') => {
+                app.input_mode = InputMode::Normal;
+            }
+            _ => {}
+        }
+        return;
+    }
+
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+        app.action_tx.send(Action::Quit).ok();
+        return;
+    }
+
+    match &app.input_mode {
+        InputMode::SearchInput => handle_search_input(app, key),
+        InputMode::LoginEmail => handle_login_email(app, key),
+        InputMode::LoginPassword => handle_login_password(app, key),
+        InputMode::LoginAuthCode => handle_login_auth_code(app, key),
+        InputMode::Normal => handle_normal(app, key),
+        InputMode::Popup(_) => unreachable!(),
+    }
+}
+
+fn handle_normal(app: &mut App_, key: KeyEvent) {
+    match key.code {
+        KeyCode::Char('q') => {
+            app.action_tx.send(Action::Quit).ok();
+        }
+        KeyCode::Tab => {
+            let next = match app.active_tab {
+                ActiveTab::Search => ActiveTab::Library,
+                ActiveTab::Library => ActiveTab::Downloads,
+                ActiveTab::Downloads => ActiveTab::Account,
+                ActiveTab::Account => ActiveTab::Search,
+            };
+            app.action_tx.send(Action::SwitchTab(next)).ok();
+        }
+        KeyCode::BackTab => {
+            let prev = match app.active_tab {
+                ActiveTab::Search => ActiveTab::Account,
+                ActiveTab::Library => ActiveTab::Search,
+                ActiveTab::Downloads => ActiveTab::Library,
+                ActiveTab::Account => ActiveTab::Downloads,
+            };
+            app.action_tx.send(Action::SwitchTab(prev)).ok();
+        }
+        KeyCode::Char('1') => {
+            app.action_tx
+                .send(Action::SwitchTab(ActiveTab::Search))
+                .ok();
+        }
+        KeyCode::Char('2') => {
+            app.action_tx
+                .send(Action::SwitchTab(ActiveTab::Library))
+                .ok();
+        }
+        KeyCode::Char('3') => {
+            app.action_tx
+                .send(Action::SwitchTab(ActiveTab::Downloads))
+                .ok();
+        }
+        KeyCode::Char('4') => {
+            app.action_tx
+                .send(Action::SwitchTab(ActiveTab::Account))
+                .ok();
+        }
+        _ => match app.active_tab {
+            ActiveTab::Search => handle_search_normal(app, key),
+            ActiveTab::Downloads => handle_downloads_normal(app, key),
+            ActiveTab::Account => handle_account_normal(app, key),
+            ActiveTab::Library => {}
+        },
+    }
+}
+
+fn handle_search_normal(app: &mut App_, key: KeyEvent) {
+    match key.code {
+        KeyCode::Char('/') | KeyCode::Char('s') => {
+            app.input_mode = InputMode::SearchInput;
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            if !app.search_results.is_empty() {
+                let i = app.search_table_state.selected().map_or(0, |i| {
+                    if i >= app.search_results.len() - 1 {
+                        0
+                    } else {
+                        i + 1
+                    }
+                });
+                app.search_table_state.select(Some(i));
+                app.update_selected_detail();
+            }
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            if !app.search_results.is_empty() {
+                let i = app.search_table_state.selected().map_or(0, |i| {
+                    if i == 0 {
+                        app.search_results.len() - 1
+                    } else {
+                        i - 1
+                    }
+                });
+                app.search_table_state.select(Some(i));
+                app.update_selected_detail();
+            }
+        }
+        KeyCode::Char('d') => {
+            if let Some(selected) = app.selected_app() {
+                app.action_tx
+                    .send(Action::StartDownload {
+                        bundle_id: selected.bundle_id.clone(),
+                        app_name: selected.name.clone(),
+                        app_id: selected.id,
+                    })
+                    .ok();
+            }
+        }
+        KeyCode::Char('p') => {
+            if let Some(selected) = app.selected_app() {
+                app.action_tx
+                    .send(Action::Purchase(selected.id, selected.name.clone()))
+                    .ok();
+            }
+        }
+        _ => {}
+    }
+}
+
+fn handle_downloads_normal(app: &mut App_, key: KeyEvent) {
+    match key.code {
+        KeyCode::Down | KeyCode::Char('j') => {
+            if !app.downloads.is_empty() {
+                let i = app.download_list_state.selected().map_or(0, |i| {
+                    if i >= app.downloads.len() - 1 {
+                        0
+                    } else {
+                        i + 1
+                    }
+                });
+                app.download_list_state.select(Some(i));
+            }
+        }
+        KeyCode::Up | KeyCode::Char('k') if !app.downloads.is_empty() => {
+            let i = app.download_list_state.selected().map_or(0, |i| {
+                if i == 0 {
+                    app.downloads.len() - 1
+                } else {
+                    i - 1
+                }
+            });
+            app.download_list_state.select(Some(i));
+        }
+        KeyCode::Char('x') => {
+            if let Some(idx) = app.download_list_state.selected() {
+                if let Some(dl) = app.downloads.get(idx) {
+                    app.action_tx.send(Action::CancelDownload(dl.id)).ok();
+                }
+            }
+        }
+        KeyCode::Char('c') => {
+            app.action_tx.send(Action::ClearFinishedDownloads).ok();
+        }
+        _ => {}
+    }
+}
+
+fn handle_account_normal(app: &mut App_, key: KeyEvent) {
+    match key.code {
+        KeyCode::Char('l') => {
+            if app.account.is_none() {
+                app.input_mode = InputMode::LoginEmail;
+                app.login_error = None;
+                app.login_auth_code = tui_input::Input::default();
+                app.login_needs_auth_code = false;
+            }
+        }
+        KeyCode::Char('r') if app.account.is_some() => {
+            app.action_tx.send(Action::Logout).ok();
+        }
+        _ => {}
+    }
+}
+
+fn handle_search_input(app: &mut App_, key: KeyEvent) {
+    match key.code {
+        KeyCode::Enter => {
+            app.input_mode = InputMode::Normal;
+            app.action_tx.send(Action::SubmitSearch).ok();
+        }
+        KeyCode::Esc => {
+            app.input_mode = InputMode::Normal;
+        }
+        _ => {
+            app.search_input
+                .handle_event(&crossterm::event::Event::Key(key));
+        }
+    }
+}
+
+fn handle_login_email(app: &mut App_, key: KeyEvent) {
+    match key.code {
+        KeyCode::Enter | KeyCode::Tab => {
+            app.input_mode = InputMode::LoginPassword;
+        }
+        KeyCode::Esc => {
+            app.input_mode = InputMode::Normal;
+        }
+        _ => {
+            app.login_email
+                .handle_event(&crossterm::event::Event::Key(key));
+        }
+    }
+}
+
+fn handle_login_password(app: &mut App_, key: KeyEvent) {
+    match key.code {
+        KeyCode::Enter => {
+            if app.login_needs_auth_code {
+                app.input_mode = InputMode::LoginAuthCode;
+            } else {
+                app.input_mode = InputMode::Normal;
+                app.action_tx.send(Action::SubmitLogin).ok();
+            }
+        }
+        KeyCode::Tab if app.login_needs_auth_code => {
+            app.input_mode = InputMode::LoginAuthCode;
+        }
+        KeyCode::Esc => {
+            app.input_mode = InputMode::Normal;
+        }
+        KeyCode::Backspace => {
+            app.login_password.pop();
+        }
+        KeyCode::Char(c) => {
+            app.login_password.push(c);
+        }
+        _ => {}
+    }
+}
+
+fn handle_login_auth_code(app: &mut App_, key: KeyEvent) {
+    match key.code {
+        KeyCode::Enter => {
+            app.input_mode = InputMode::Normal;
+            app.action_tx.send(Action::SubmitLogin).ok();
+        }
+        KeyCode::Esc => {
+            app.input_mode = InputMode::Normal;
+        }
+        _ => {
+            app.login_auth_code
+                .handle_event(&crossterm::event::Event::Key(key));
+        }
+    }
+}

--- a/crates/ipatool-cli/src/tui/handler.rs
+++ b/crates/ipatool-cli/src/tui/handler.rs
@@ -160,10 +160,10 @@ fn handle_downloads_normal(app: &mut App_, key: KeyEvent) {
             app.download_list_state.select(Some(i));
         }
         KeyCode::Char('x') => {
-            if let Some(idx) = app.download_list_state.selected() {
-                if let Some(dl) = app.downloads.get(idx) {
-                    app.action_tx.send(Action::CancelDownload(dl.id)).ok();
-                }
+            if let Some(idx) = app.download_list_state.selected()
+                && let Some(dl) = app.downloads.get(idx)
+            {
+                app.action_tx.send(Action::CancelDownload(dl.id)).ok();
             }
         }
         KeyCode::Char('c') => {

--- a/crates/ipatool-cli/src/tui/mod.rs
+++ b/crates/ipatool-cli/src/tui/mod.rs
@@ -695,7 +695,8 @@ async fn acquire_download_item(
     id: usize,
 ) -> Result<ipatool_core::api::download::DownloadItem, String> {
     let max_attempts = 3;
-    let mut purchased = false;
+    let mut purchase_attempted = false;
+    let mut last_error = None;
 
     for attempt in 0..max_attempts {
         let result = {
@@ -705,7 +706,8 @@ async fn acquire_download_item(
 
         match result {
             Ok(item) => return Ok(item),
-            Err(e) if e.is_license_not_found() && !purchased => {
+            Err(e) if e.is_license_not_found() && !purchase_attempted => {
+                last_error = Some(e.to_string());
                 tx.send(Action::DownloadProgress {
                     id,
                     stage: DownloadStage::Purchasing,
@@ -714,7 +716,7 @@ async fn acquire_download_item(
                 })
                 .ok();
                 purchase_for_download(client, app_id, account, tx).await?;
-                purchased = true;
+                purchase_attempted = true;
                 tx.send(Action::StatusMessage(
                     "Purchase successful, fetching download info...".into(),
                 ))
@@ -724,6 +726,7 @@ async fn acquire_download_item(
                 return Err("license not found after purchase".into());
             }
             Err(e) if e.is_token_expired() && attempt + 1 < max_attempts => {
+                last_error = Some(e.to_string());
                 tx.send(Action::StatusMessage(
                     "Token expired, re-authenticating...".into(),
                 ))
@@ -742,7 +745,10 @@ async fn acquire_download_item(
         }
     }
 
-    Err("failed to get download info after retries".into())
+    Err(last_error.map_or_else(
+        || "failed to get download info after retries".into(),
+        |e| format!("failed to get download info after retries: {e}"),
+    ))
 }
 
 async fn purchase_for_download(

--- a/crates/ipatool-cli/src/tui/mod.rs
+++ b/crates/ipatool-cli/src/tui/mod.rs
@@ -190,7 +190,8 @@ async fn process_action(app: &mut App_, action: Action) {
                 error: None,
                 cancel_token: cancel_token.clone(),
             });
-            app.download_list_state.select(Some(app.downloads.len() - 1));
+            app.download_list_state
+                .select(Some(app.downloads.len() - 1));
             app.status_message = format!("Queued {app_name} — see Downloads tab");
 
             let client = Arc::clone(&app.client);
@@ -207,7 +208,17 @@ async fn process_action(app: &mut App_, action: Action) {
                     tx.send(Action::DownloadCancelled(id)).ok();
                     return;
                 }
-                run_download_task(client, app_id, bundle_id, app_name, account, tx, id, cancel_token).await;
+                run_download_task(
+                    client,
+                    app_id,
+                    bundle_id,
+                    app_name,
+                    account,
+                    tx,
+                    id,
+                    cancel_token,
+                )
+                .await;
             });
         }
         Action::DownloadProgress {
@@ -240,13 +251,13 @@ async fn process_action(app: &mut App_, action: Action) {
             }
         }
         Action::CancelDownload(id) => {
-            if let Some(dl) = app.download_by_id(id) {
-                if !matches!(
+            if let Some(dl) = app.download_by_id(id)
+                && !matches!(
                     dl.stage,
                     DownloadStage::Complete | DownloadStage::Failed | DownloadStage::Cancelled
-                ) {
-                    dl.cancel_token.cancel();
-                }
+                )
+            {
+                dl.cancel_token.cancel();
             }
         }
         Action::DownloadCancelled(id) => {
@@ -517,7 +528,13 @@ fn render_status_bar(f: &mut ratatui::Frame, app: &App_, area: Rect) {
                 ("Tab", "next"),
             ],
             ActiveTab::Library => &[("q", "quit"), ("Tab", "next")],
-            ActiveTab::Downloads => &[("q", "quit"), ("j/k", "nav"), ("x", "cancel"), ("c", "clear"), ("Tab", "next")],
+            ActiveTab::Downloads => &[
+                ("q", "quit"),
+                ("j/k", "nav"),
+                ("x", "cancel"),
+                ("c", "clear"),
+                ("Tab", "next"),
+            ],
             ActiveTab::Account if app.account.is_some() => {
                 &[("q", "quit"), ("r", "revoke"), ("Tab", "next")]
             }
@@ -598,6 +615,7 @@ async fn tui_reauth(
     Ok(new_account)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_download_task(
     client: Arc<Mutex<AppleClient>>,
     app_id: i64,

--- a/crates/ipatool-cli/src/tui/mod.rs
+++ b/crates/ipatool-cli/src/tui/mod.rs
@@ -1,0 +1,840 @@
+pub mod action;
+pub mod app;
+pub mod event;
+pub mod handler;
+pub mod tabs;
+pub mod theme;
+
+use std::io;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use tokio::sync::Mutex;
+use tokio::sync::mpsc;
+
+use ipatool_core::client::AppleClient;
+
+use tokio_util::sync::CancellationToken;
+
+use futures_util::StreamExt;
+use tokio::io::AsyncWriteExt;
+
+use crate::data_dir;
+
+use self::action::Action;
+use self::app::{ActiveTab, App_, DownloadStage, InputMode};
+use self::event::{Event, EventHandler};
+
+pub async fn run() -> Result<()> {
+    let guid_str = ipatool_core::guid::generate_guid().context("failed to generate GUID")?;
+    let data_dir = data_dir();
+    std::fs::create_dir_all(&data_dir).ok();
+    let cookie_path = data_dir.join("cookies.json");
+
+    let client =
+        AppleClient::new(guid_str, Some(&cookie_path)).context("failed to create client")?;
+
+    let (action_tx, action_rx) = mpsc::unbounded_channel::<Action>();
+    let mut app = App_::new(client, action_tx.clone());
+
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let result = run_loop(&mut terminal, &mut app, action_rx, &cookie_path).await;
+
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    terminal.show_cursor()?;
+
+    result
+}
+
+async fn run_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut App_,
+    mut action_rx: mpsc::UnboundedReceiver<Action>,
+    cookie_path: &std::path::Path,
+) -> Result<()> {
+    let mut events = EventHandler::new();
+    let mut needs_redraw = true;
+
+    loop {
+        if app.should_quit {
+            let client = app.client.lock().await;
+            client.save_cookies(cookie_path).ok();
+            break;
+        }
+
+        if needs_redraw {
+            terminal.draw(|f| ui(f, app))?;
+            needs_redraw = false;
+        }
+
+        tokio::select! {
+            event = events.next() => {
+                match event? {
+                    Event::Key(key) => {
+                        handler::handle_key(app, key);
+                        needs_redraw = true;
+                    }
+                    Event::Tick => {}
+                    Event::Render => {
+                        needs_redraw = true;
+                    }
+                    Event::Resize(_, _) => {
+                        needs_redraw = true;
+                    }
+                }
+            }
+            Some(action) = action_rx.recv() => {
+                process_action(app, action).await;
+                needs_redraw = true;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn process_action(app: &mut App_, action: Action) {
+    match action {
+        Action::Quit => {
+            app.should_quit = true;
+        }
+        Action::Tick | Action::Render => {}
+        Action::SwitchTab(tab) => {
+            app.active_tab = tab;
+        }
+        Action::SubmitSearch => {
+            let query = app.search_input.value().to_string();
+            if query.is_empty() {
+                return;
+            }
+            app.is_loading = true;
+            app.search_results.clear();
+            app.search_table_state.select(None);
+            app.selected_detail = None;
+            app.status_message = format!("Searching for \"{query}\"...");
+
+            let client = Arc::clone(&app.client);
+            let tx = app.action_tx.clone();
+            let country = app.search_country.clone();
+            let platform = app.search_platform;
+
+            tokio::spawn(async move {
+                let result = {
+                    let c = client.lock().await;
+                    ipatool_core::api::search::search(&c, &query, &country, platform, 25).await
+                };
+                match result {
+                    Ok(apps) => {
+                        tx.send(Action::SearchResults(apps)).ok();
+                    }
+                    Err(e) => {
+                        tx.send(Action::SearchError(e.to_string())).ok();
+                    }
+                }
+            });
+        }
+        Action::SearchResults(apps) => {
+            app.is_loading = false;
+            let count = apps.len();
+            app.search_results = apps;
+            if !app.search_results.is_empty() {
+                app.search_table_state.select(Some(0));
+                app.update_selected_detail();
+            }
+            app.status_message = format!("Found {count} results");
+        }
+        Action::SearchError(err) => {
+            app.is_loading = false;
+            app.status_message = format!("Search error: {err}");
+        }
+        Action::StartDownload {
+            bundle_id,
+            app_name,
+            app_id,
+        } => {
+            if app.account.is_none() {
+                app.status_message = "Login required to download".to_string();
+                return;
+            }
+
+            let cancel_token = CancellationToken::new();
+            let id = app.next_download_id;
+            app.next_download_id += 1;
+            app.downloads.push(app::DownloadTask {
+                id,
+                app_name: app_name.clone(),
+                stage: DownloadStage::Queued,
+                progress: 0,
+                total: 0,
+                error: None,
+                cancel_token: cancel_token.clone(),
+            });
+            app.download_list_state.select(Some(app.downloads.len() - 1));
+            app.status_message = format!("Queued {app_name} — see Downloads tab");
+
+            let client = Arc::clone(&app.client);
+            let tx = app.action_tx.clone();
+            let account = app.account.clone().unwrap();
+            let semaphore = Arc::clone(&app.download_semaphore);
+
+            tokio::spawn(async move {
+                let _permit = match semaphore.acquire().await {
+                    Ok(p) => p,
+                    Err(_) => return,
+                };
+                if cancel_token.is_cancelled() {
+                    tx.send(Action::DownloadCancelled(id)).ok();
+                    return;
+                }
+                run_download_task(client, app_id, bundle_id, app_name, account, tx, id, cancel_token).await;
+            });
+        }
+        Action::DownloadProgress {
+            id,
+            stage,
+            progress,
+            total,
+        } => {
+            if let Some(dl) = app.download_by_id_mut(id) {
+                dl.stage = stage;
+                dl.progress = progress;
+                dl.total = total;
+            }
+        }
+        Action::DownloadComplete(id) => {
+            if let Some(dl) = app.download_by_id_mut(id) {
+                dl.stage = DownloadStage::Complete;
+            }
+        }
+        Action::DownloadError { id, error } => {
+            if let Some(dl) = app.download_by_id_mut(id) {
+                if dl.cancel_token.is_cancelled() {
+                    dl.stage = DownloadStage::Cancelled;
+                    app.status_message = "Download cancelled".to_string();
+                } else {
+                    dl.stage = DownloadStage::Failed;
+                    dl.error = Some(error.clone());
+                    app.status_message = format!("Download failed: {error}");
+                }
+            }
+        }
+        Action::CancelDownload(id) => {
+            if let Some(dl) = app.download_by_id(id) {
+                if !matches!(
+                    dl.stage,
+                    DownloadStage::Complete | DownloadStage::Failed | DownloadStage::Cancelled
+                ) {
+                    dl.cancel_token.cancel();
+                }
+            }
+        }
+        Action::DownloadCancelled(id) => {
+            if let Some(dl) = app.download_by_id_mut(id) {
+                dl.stage = DownloadStage::Cancelled;
+            }
+            app.status_message = "Download cancelled".to_string();
+        }
+        Action::ClearFinishedDownloads => {
+            app.clear_finished_downloads();
+            app.status_message = "Cleared finished downloads".to_string();
+        }
+        Action::SubmitLogin => {
+            let email = app.login_email.value().to_string();
+            let password = app.login_password.clone();
+            if email.is_empty() || password.is_empty() {
+                app.login_error = Some("Email and password required".to_string());
+                return;
+            }
+
+            let auth_code = if app.login_needs_auth_code {
+                let code = app.login_auth_code.value().trim().to_string();
+                if code.is_empty() {
+                    app.input_mode = InputMode::LoginAuthCode;
+                    app.login_error = Some("Two-factor authentication code required".to_string());
+                    return;
+                }
+                Some(code)
+            } else {
+                None
+            };
+
+            app.status_message = "Logging in...".to_string();
+            app.login_error = None;
+
+            let client = Arc::clone(&app.client);
+            let tx = app.action_tx.clone();
+
+            tokio::spawn(async move {
+                let auth_url = {
+                    let c = client.lock().await;
+                    ipatool_core::api::bag::fetch_auth_endpoint(&c).await
+                };
+
+                let auth_url = match auth_url {
+                    Ok(url) => url,
+                    Err(e) => {
+                        tx.send(Action::LoginError(e.to_string())).ok();
+                        return;
+                    }
+                };
+
+                let account = {
+                    let c = client.lock().await;
+                    ipatool_core::api::auth::login(
+                        &c,
+                        &email,
+                        &password,
+                        auth_code.as_deref(),
+                        &auth_url,
+                    )
+                    .await
+                };
+
+                match account {
+                    Ok(mut account) => {
+                        account.password = Some(password);
+                        if let Err(e) = ipatool_core::credential::store_account(&account) {
+                            tx.send(Action::LoginError(format!("save failed: {e}")))
+                                .ok();
+                            return;
+                        }
+                        {
+                            let mut c = client.lock().await;
+                            c.set_account(account.clone());
+                        }
+                        tx.send(Action::LoginSuccess(account)).ok();
+                    }
+                    Err(e)
+                        if matches!(
+                            &e,
+                            ipatool_core::error::ClientError::Store(
+                                ipatool_core::error::StoreError::AuthCodeRequired
+                            )
+                        ) =>
+                    {
+                        tx.send(Action::LoginNeedsAuthCode).ok();
+                    }
+                    Err(e) => {
+                        tx.send(Action::LoginError(e.to_string())).ok();
+                    }
+                }
+            });
+        }
+        Action::LoginNeedsAuthCode => {
+            app.login_needs_auth_code = true;
+            app.login_auth_code = tui_input::Input::default();
+            app.input_mode = InputMode::LoginAuthCode;
+            app.login_error = Some("Two-factor authentication code required".to_string());
+            app.status_message = "Enter two-factor authentication code".to_string();
+        }
+        Action::LoginSuccess(account) => {
+            if let Some(country) =
+                ipatool_core::model::storefront::country_code_from_store_front(&account.store_front)
+            {
+                app.search_country = country.to_string();
+            }
+            app.account = Some(account);
+            app.login_password.clear();
+            app.login_auth_code = tui_input::Input::default();
+            app.login_needs_auth_code = false;
+            app.status_message = "Logged in successfully".to_string();
+        }
+        Action::LoginError(err) => {
+            if app.login_needs_auth_code {
+                app.input_mode = InputMode::LoginAuthCode;
+            }
+            app.login_error = Some(err.clone());
+            app.status_message = format!("Login failed: {err}");
+        }
+        Action::AccountRefreshed(account) => {
+            app.account = Some(account);
+        }
+        Action::Logout => {
+            if let Err(e) = ipatool_core::credential::delete_account() {
+                app.status_message = format!("Logout failed: {e}");
+            } else {
+                app.account = None;
+                app.login_auth_code = tui_input::Input::default();
+                app.login_needs_auth_code = false;
+                app.status_message = "Logged out".to_string();
+            }
+        }
+        Action::Purchase(app_id, name) => {
+            if app.account.is_none() {
+                app.status_message = "Login required to purchase".to_string();
+                return;
+            }
+            app.status_message = format!("Purchasing {name}...");
+
+            let client = Arc::clone(&app.client);
+            let tx = app.action_tx.clone();
+            let account = app.account.clone().unwrap();
+
+            tokio::spawn(async move {
+                let result = {
+                    let c = client.lock().await;
+                    ipatool_core::api::purchase::purchase(&c, app_id, &account).await
+                };
+                match result {
+                    Ok(()) => {
+                        tx.send(Action::PurchaseSuccess(name)).ok();
+                    }
+                    Err(e) if e.is_token_expired() => {
+                        let reauth_result = {
+                            let c = client.lock().await;
+                            tui_reauth(&c, &account).await
+                        };
+                        match reauth_result {
+                            Ok(new_acc) => {
+                                tx.send(Action::AccountRefreshed(new_acc.clone())).ok();
+                                let mut c = client.lock().await;
+                                c.set_account(new_acc.clone());
+                                match ipatool_core::api::purchase::purchase(&c, app_id, &new_acc)
+                                    .await
+                                {
+                                    Ok(()) => {
+                                        tx.send(Action::PurchaseSuccess(name)).ok();
+                                    }
+                                    Err(e) => {
+                                        tx.send(Action::PurchaseError(e.to_string())).ok();
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                tx.send(Action::PurchaseError(format!("re-auth failed: {e}")))
+                                    .ok();
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tx.send(Action::PurchaseError(e.to_string())).ok();
+                    }
+                }
+            });
+        }
+        Action::PurchaseSuccess(name) => {
+            app.status_message = format!("Purchased: {name}");
+        }
+        Action::PurchaseError(err) => {
+            app.status_message = format!("Purchase failed: {err}");
+        }
+        Action::ShowPopup(msg) => {
+            app.input_mode = InputMode::Popup(msg);
+        }
+        Action::ClosePopup => {
+            app.input_mode = InputMode::Normal;
+        }
+        Action::StatusMessage(msg) => {
+            app.status_message = msg;
+        }
+    }
+}
+
+fn ui(f: &mut ratatui::Frame, app: &mut App_) {
+    let bg = Block::default().style(theme::base());
+    f.render_widget(bg, f.area());
+
+    let chunks = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Min(5),
+        Constraint::Length(1),
+    ])
+    .split(f.area());
+
+    render_tabs(f, app, chunks[0]);
+    tabs::render_tab(f, app, chunks[1]);
+    render_status_bar(f, app, chunks[2]);
+
+    if let InputMode::Popup(ref msg) = app.input_mode {
+        render_popup(f, msg);
+    }
+}
+
+fn render_tabs(f: &mut ratatui::Frame, app: &App_, area: Rect) {
+    let mut spans = vec![Span::styled(" ", theme::tab_inactive())];
+
+    for tab in &ActiveTab::ALL {
+        let label = format!(" {} ", tab.title());
+        if *tab == app.active_tab {
+            spans.push(Span::styled(label, theme::tab_active()));
+        } else {
+            spans.push(Span::styled(label, theme::tab_inactive()));
+        }
+        spans.push(Span::styled(" ", theme::tab_inactive()));
+    }
+
+    let country = &app.search_country;
+    let account_hint = if app.account.is_some() {
+        format!("[{country}] ")
+    } else {
+        "not logged in ".to_string()
+    };
+    let remaining = area
+        .width
+        .saturating_sub(spans.iter().map(|s| s.width() as u16).sum::<u16>());
+    if remaining > account_hint.len() as u16 {
+        let pad = remaining - account_hint.len() as u16;
+        spans.push(Span::styled(
+            " ".repeat(pad as usize),
+            theme::tab_inactive(),
+        ));
+        spans.push(Span::styled(account_hint, theme::label()));
+    }
+
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn render_status_bar(f: &mut ratatui::Frame, app: &App_, area: Rect) {
+    let keys: &[(&str, &str)] = match app.input_mode {
+        InputMode::Normal => match app.active_tab {
+            ActiveTab::Search => &[
+                ("q", "quit"),
+                ("/", "search"),
+                ("j/k", "nav"),
+                ("d", "download"),
+                ("p", "purchase"),
+                ("Tab", "next"),
+            ],
+            ActiveTab::Library => &[("q", "quit"), ("Tab", "next")],
+            ActiveTab::Downloads => &[("q", "quit"), ("j/k", "nav"), ("x", "cancel"), ("c", "clear"), ("Tab", "next")],
+            ActiveTab::Account if app.account.is_some() => {
+                &[("q", "quit"), ("r", "revoke"), ("Tab", "next")]
+            }
+            ActiveTab::Account => &[("q", "quit"), ("l", "login"), ("Tab", "next")],
+        },
+        InputMode::SearchInput => &[("Enter", "search"), ("Esc", "cancel")],
+        InputMode::LoginEmail => &[("Tab", "next"), ("Esc", "cancel")],
+        InputMode::LoginPassword => &[("Enter", "submit"), ("Esc", "cancel")],
+        InputMode::LoginAuthCode => &[("Enter", "submit"), ("Esc", "cancel")],
+        InputMode::Popup(_) => &[("Esc", "close")],
+    };
+
+    let mut spans = vec![Span::styled(
+        format!(" {} ", app.status_message),
+        theme::status_bar(),
+    )];
+
+    let status_len: usize = spans.iter().map(|s| s.width()).sum();
+    let keys_len: usize = keys.iter().map(|(k, d)| k.len() + d.len() + 3).sum();
+    let pad = area.width.saturating_sub((status_len + keys_len) as u16) as usize;
+    spans.push(Span::styled(" ".repeat(pad), theme::status_bar()));
+
+    for (key, desc) in keys {
+        spans.push(Span::styled(format!(" {key}"), theme::status_key()));
+        spans.push(Span::styled(format!(" {desc}"), theme::status_desc()));
+    }
+
+    let bar = Paragraph::new(Line::from(spans));
+    f.render_widget(bar, area);
+}
+
+fn render_popup(f: &mut ratatui::Frame, msg: &str) {
+    let area = f.area();
+    let popup_width = (area.width * 60 / 100).max(30).min(area.width - 4);
+    let popup_height = 7u16.min(area.height - 2);
+    let x = (area.width - popup_width) / 2;
+    let y = (area.height - popup_height) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    let popup = Paragraph::new(msg)
+        .style(theme::surface())
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(theme::border_active())
+                .title(" Info "),
+        )
+        .wrap(Wrap { trim: true });
+
+    f.render_widget(ratatui::widgets::Clear, popup_area);
+    f.render_widget(popup, popup_area);
+}
+
+pub(super) fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = 1024 * KB;
+    const GB: u64 = 1024 * MB;
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+async fn tui_reauth(
+    client: &AppleClient,
+    account: &ipatool_core::model::Account,
+) -> Result<ipatool_core::model::Account> {
+    let new_account = ipatool_core::api::reauth::reauthenticate(client, account)
+        .await
+        .context("re-authentication failed")?;
+    ipatool_core::credential::store_account(&new_account)
+        .context("failed to store refreshed credentials")?;
+    Ok(new_account)
+}
+
+async fn run_download_task(
+    client: Arc<Mutex<AppleClient>>,
+    app_id: i64,
+    bundle_id: String,
+    app_name: String,
+    account: ipatool_core::model::Account,
+    tx: mpsc::UnboundedSender<Action>,
+    id: usize,
+    cancel_token: CancellationToken,
+) {
+    let mut account = account;
+
+    let item = match acquire_download_item(&client, app_id, &mut account, &tx, id).await {
+        Ok(item) => item,
+        Err(e) => {
+            tx.send(Action::DownloadError { id, error: e }).ok();
+            return;
+        }
+    };
+
+    let version = item
+        .metadata
+        .get("bundleShortVersionString")
+        .and_then(|v| v.as_string())
+        .unwrap_or("unknown");
+
+    let filename = format!("{bundle_id}_{app_id}_{version}.ipa");
+    let dest = PathBuf::from(&filename);
+    let tmp_path = dest.with_extension("ipa.tmp");
+
+    tx.send(Action::StatusMessage(format!(
+        "Downloading {app_name} — see Downloads tab"
+    )))
+    .ok();
+
+    if let Err(e) = stream_download(&client, &item.url, &tmp_path, &tx, id, &cancel_token).await {
+        std::fs::remove_file(&tmp_path).ok();
+        if cancel_token.is_cancelled() {
+            tx.send(Action::DownloadCancelled(id)).ok();
+        } else {
+            tx.send(Action::DownloadError { id, error: e }).ok();
+        }
+        return;
+    }
+
+    tx.send(Action::DownloadProgress {
+        id,
+        stage: DownloadStage::Patching,
+        progress: 0,
+        total: 0,
+    })
+    .ok();
+
+    if let Err(e) = ipatool_core::ipa::patch::patch_ipa(&tmp_path, &dest, &item, &account.email) {
+        std::fs::remove_file(&tmp_path).ok();
+        tx.send(Action::DownloadError {
+            id,
+            error: e.to_string(),
+        })
+        .ok();
+        return;
+    }
+
+    std::fs::remove_file(&tmp_path).ok();
+    tx.send(Action::DownloadComplete(id)).ok();
+    tx.send(Action::StatusMessage(format!(
+        "Download complete: {filename}"
+    )))
+    .ok();
+}
+
+async fn acquire_download_item(
+    client: &Arc<Mutex<AppleClient>>,
+    app_id: i64,
+    account: &mut ipatool_core::model::Account,
+    tx: &mpsc::UnboundedSender<Action>,
+    id: usize,
+) -> Result<ipatool_core::api::download::DownloadItem, String> {
+    let max_attempts = 3;
+    let mut purchased = false;
+
+    for attempt in 0..max_attempts {
+        let result = {
+            let c = client.lock().await;
+            ipatool_core::api::download::get_download_info(&c, app_id, account, None).await
+        };
+
+        match result {
+            Ok(item) => return Ok(item),
+            Err(e) if e.is_license_not_found() && !purchased => {
+                tx.send(Action::DownloadProgress {
+                    id,
+                    stage: DownloadStage::Purchasing,
+                    progress: 0,
+                    total: 0,
+                })
+                .ok();
+                purchase_for_download(client, app_id, account, tx).await?;
+                purchased = true;
+                tx.send(Action::StatusMessage(
+                    "Purchase successful, fetching download info...".into(),
+                ))
+                .ok();
+            }
+            Err(e) if e.is_license_not_found() => {
+                return Err("license not found after purchase".into());
+            }
+            Err(e) if e.is_token_expired() && attempt + 1 < max_attempts => {
+                tx.send(Action::StatusMessage(
+                    "Token expired, re-authenticating...".into(),
+                ))
+                .ok();
+                let new_acc = {
+                    let c = client.lock().await;
+                    tui_reauth(&c, account)
+                        .await
+                        .map_err(|e| format!("re-auth failed: {e}"))?
+                };
+                *account = new_acc.clone();
+                tx.send(Action::AccountRefreshed(new_acc.clone())).ok();
+                client.lock().await.set_account(new_acc);
+            }
+            Err(e) => return Err(e.to_string()),
+        }
+    }
+
+    Err("failed to get download info after retries".into())
+}
+
+async fn purchase_for_download(
+    client: &Arc<Mutex<AppleClient>>,
+    app_id: i64,
+    account: &mut ipatool_core::model::Account,
+    tx: &mpsc::UnboundedSender<Action>,
+) -> Result<(), String> {
+    let result = {
+        let c = client.lock().await;
+        ipatool_core::api::purchase::purchase(&c, app_id, account).await
+    };
+    match result {
+        Ok(()) => Ok(()),
+        Err(e) if e.is_token_expired() => {
+            tx.send(Action::StatusMessage(
+                "Token expired, re-authenticating...".into(),
+            ))
+            .ok();
+            let new_acc = {
+                let c = client.lock().await;
+                tui_reauth(&c, account)
+                    .await
+                    .map_err(|e| format!("re-auth failed: {e}"))?
+            };
+            *account = new_acc.clone();
+            tx.send(Action::AccountRefreshed(new_acc)).ok();
+            let mut c = client.lock().await;
+            c.set_account(account.clone());
+            match ipatool_core::api::purchase::purchase(&c, app_id, account).await {
+                Ok(()) => Ok(()),
+                Err(e) if e.is_license_already_exists() => Ok(()),
+                Err(e) => Err(format!("purchase failed after re-auth: {e}")),
+            }
+        }
+        Err(e) if e.is_license_already_exists() => Ok(()),
+        Err(e) => Err(format!("purchase failed: {e}")),
+    }
+}
+
+async fn stream_download(
+    client: &Arc<Mutex<AppleClient>>,
+    url: &str,
+    tmp_path: &std::path::Path,
+    tx: &mpsc::UnboundedSender<Action>,
+    id: usize,
+    cancel_token: &CancellationToken,
+) -> Result<(), String> {
+    let http = {
+        let c = client.lock().await;
+        c.http().clone()
+    };
+
+    let resp = http.get(url).send().await.map_err(|e| e.to_string())?;
+    let total_size = resp.content_length().unwrap_or(0);
+
+    tx.send(Action::DownloadProgress {
+        id,
+        stage: DownloadStage::Downloading,
+        progress: 0,
+        total: total_size,
+    })
+    .ok();
+
+    let mut file = tokio::fs::File::create(tmp_path)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let mut stream = resp.bytes_stream();
+    let mut downloaded: u64 = 0;
+    let mut last_progress = tokio::time::Instant::now();
+    let progress_interval = std::time::Duration::from_millis(100);
+
+    loop {
+        tokio::select! {
+            chunk = stream.next() => {
+                match chunk {
+                    Some(Ok(bytes)) => {
+                        file.write_all(&bytes).await.map_err(|_| "write error".to_string())?;
+                        downloaded += bytes.len() as u64;
+                        let now = tokio::time::Instant::now();
+                        if now.duration_since(last_progress) >= progress_interval {
+                            last_progress = now;
+                            tx.send(Action::DownloadProgress {
+                                id,
+                                stage: DownloadStage::Downloading,
+                                progress: downloaded,
+                                total: total_size,
+                            })
+                            .ok();
+                        }
+                    }
+                    Some(Err(e)) => return Err(e.to_string()),
+                    None => break,
+                }
+            }
+            _ = cancel_token.cancelled() => {
+                return Err("cancelled".into());
+            }
+        }
+    }
+
+    tx.send(Action::DownloadProgress {
+        id,
+        stage: DownloadStage::Downloading,
+        progress: downloaded,
+        total: total_size,
+    })
+    .ok();
+
+    file.flush().await.map_err(|_| "flush error".to_string())?;
+    Ok(())
+}

--- a/crates/ipatool-cli/src/tui/tabs/account.rs
+++ b/crates/ipatool-cli/src/tui/tabs/account.rs
@@ -1,0 +1,238 @@
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::Modifier;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+
+use crate::tui::app::{App_, InputMode};
+use crate::tui::theme;
+
+pub fn render(f: &mut Frame, app: &mut App_, area: Rect) {
+    let bg = Block::default().style(theme::base());
+    f.render_widget(bg, area);
+
+    if let Some(ref account) = app.account {
+        render_logged_in(f, account, area);
+    } else {
+        render_login_form(f, app, area);
+    }
+}
+
+fn render_logged_in(f: &mut Frame, account: &ipatool_core::model::Account, area: Rect) {
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Logged In",
+            theme::success_style().add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        detail_line("  Name", &account.name),
+        detail_line("  Email", &account.email),
+        detail_line("  DSID", &account.directory_services_id),
+        detail_line("  Store", &account.store_front),
+        detail_line("  Pod", account.pod.as_deref().unwrap_or("—")),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  r", theme::tab_active()),
+            Span::styled(" revoke credentials", theme::label()),
+        ]),
+    ];
+
+    f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
+}
+
+fn render_login_form(f: &mut Frame, app: &App_, area: Rect) {
+    let email_active = app.input_mode == InputMode::LoginEmail;
+    let pass_active = app.input_mode == InputMode::LoginPassword;
+    let auth_code_active = app.input_mode == InputMode::LoginAuthCode;
+    let show_auth_code = app.login_needs_auth_code || auth_code_active;
+
+    let chunks = if show_auth_code {
+        Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(2),
+            Constraint::Length(1),
+            Constraint::Length(2),
+            Constraint::Length(1),
+            Constraint::Length(2),
+            Constraint::Length(1),
+            Constraint::Min(1),
+        ])
+        .split(area)
+    } else {
+        Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(2),
+            Constraint::Length(1),
+            Constraint::Length(2),
+            Constraint::Length(1),
+            Constraint::Min(1),
+        ])
+        .split(area)
+    };
+
+    f.render_widget(
+        Paragraph::new(Span::styled("  Login", theme::title())),
+        chunks[0],
+    );
+
+    let email_label_style = if email_active {
+        theme::border_active()
+    } else {
+        theme::label()
+    };
+    f.render_widget(
+        Paragraph::new(Span::styled("  Email", email_label_style)),
+        chunks[1],
+    );
+
+    let email_text = if app.login_email.value().is_empty() && !email_active {
+        Line::from(Span::styled("  your@email.com", theme::input_placeholder()))
+    } else {
+        Line::from(Span::styled(
+            format!("  {}", app.login_email.value()),
+            theme::input_active(),
+        ))
+    };
+    let email_border = if email_active {
+        theme::border_active()
+    } else {
+        theme::border_dim()
+    };
+    let email = Paragraph::new(email_text).block(
+        Block::default()
+            .borders(Borders::BOTTOM)
+            .border_style(email_border),
+    );
+    f.render_widget(email, chunks[2]);
+
+    if email_active {
+        let cx = chunks[2].x + app.login_email.visual_cursor() as u16 + 3;
+        let cy = chunks[2].y;
+        f.set_cursor_position((cx, cy));
+    }
+
+    let pass_label_style = if pass_active {
+        theme::border_active()
+    } else {
+        theme::label()
+    };
+    f.render_widget(
+        Paragraph::new(Span::styled("  Password", pass_label_style)),
+        chunks[3],
+    );
+
+    let masked: String = if app.login_password.is_empty() && !pass_active {
+        String::new()
+    } else {
+        "*".repeat(app.login_password.len())
+    };
+    let pass_display = if masked.is_empty() && !pass_active {
+        Line::from(Span::styled("  ••••••••", theme::input_placeholder()))
+    } else {
+        Line::from(Span::styled(format!("  {masked}"), theme::input_active()))
+    };
+    let pass_border = if pass_active {
+        theme::border_active()
+    } else {
+        theme::border_dim()
+    };
+    let password = Paragraph::new(pass_display).block(
+        Block::default()
+            .borders(Borders::BOTTOM)
+            .border_style(pass_border),
+    );
+    f.render_widget(password, chunks[4]);
+
+    if pass_active {
+        let cx = chunks[4].x + app.login_password.len() as u16 + 3;
+        let cy = chunks[4].y;
+        f.set_cursor_position((cx, cy));
+    }
+
+    let help_chunk;
+    let footer_chunk;
+
+    if show_auth_code {
+        let auth_code_label_style = if auth_code_active {
+            theme::border_active()
+        } else {
+            theme::label()
+        };
+        f.render_widget(
+            Paragraph::new(Span::styled("  Two-factor code", auth_code_label_style)),
+            chunks[5],
+        );
+
+        let auth_code_text = if app.login_auth_code.value().is_empty() && !auth_code_active {
+            Line::from(Span::styled("  123456", theme::input_placeholder()))
+        } else {
+            Line::from(Span::styled(
+                format!("  {}", app.login_auth_code.value()),
+                theme::input_active(),
+            ))
+        };
+        let auth_code_border = if auth_code_active {
+            theme::border_active()
+        } else {
+            theme::border_dim()
+        };
+        let auth_code = Paragraph::new(auth_code_text).block(
+            Block::default()
+                .borders(Borders::BOTTOM)
+                .border_style(auth_code_border),
+        );
+        f.render_widget(auth_code, chunks[6]);
+
+        if auth_code_active {
+            let cx = chunks[6].x + app.login_auth_code.visual_cursor() as u16 + 3;
+            let cy = chunks[6].y;
+            f.set_cursor_position((cx, cy));
+        }
+
+        help_chunk = chunks[7];
+        footer_chunk = chunks[8];
+    } else {
+        help_chunk = chunks[5];
+        footer_chunk = chunks[6];
+    }
+
+    let help = if let Some(ref err) = app.login_error {
+        vec![Line::from(Span::styled(
+            format!("  {err}"),
+            theme::error_style(),
+        ))]
+    } else if email_active || pass_active || auth_code_active {
+        vec![Line::from(Span::styled(
+            "  Tab: next field  Enter: submit  Esc: cancel",
+            theme::label(),
+        ))]
+    } else {
+        vec![
+            Line::from(""),
+            Line::from(Span::styled("  Press l to log in", theme::label())),
+        ]
+    };
+
+    f.render_widget(Paragraph::new(help), help_chunk);
+
+    f.render_widget(
+        Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                "  Credentials are stored in the system keychain.",
+                theme::label(),
+            )),
+        ]),
+        footer_chunk,
+    );
+}
+
+fn detail_line<'a>(label: &'a str, value: &'a str) -> Line<'a> {
+    Line::from(vec![
+        Span::styled(format!("{label}: "), theme::label()),
+        Span::styled(value, theme::value()),
+    ])
+}

--- a/crates/ipatool-cli/src/tui/tabs/download.rs
+++ b/crates/ipatool-cli/src/tui/tabs/download.rs
@@ -1,0 +1,111 @@
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, List, ListItem, Paragraph};
+
+use crate::tui::app::{App_, DownloadStage};
+use crate::tui::format_bytes;
+use crate::tui::theme;
+
+pub fn render(f: &mut Frame, app: &mut App_, area: Rect) {
+    let bg = Block::default().style(theme::base());
+    f.render_widget(bg, area);
+
+    if app.downloads.is_empty() {
+        let text = vec![
+            Line::from(""),
+            Line::from(""),
+            Line::from(Span::styled("  Downloads", theme::title())),
+            Line::from(""),
+            Line::from(Span::styled("  No active downloads.", theme::label())),
+            Line::from(Span::styled(
+                "  Search for an app and press d to download.",
+                theme::label(),
+            )),
+        ];
+        f.render_widget(Paragraph::new(text), area);
+        return;
+    }
+
+    let items: Vec<ListItem> = app
+        .downloads
+        .iter()
+        .map(|dl| {
+            let available_width = area.width.saturating_sub(4) as usize;
+
+            match dl.stage {
+                DownloadStage::Downloading if dl.total > 0 => {
+                    let ratio = dl.progress as f64 / dl.total as f64;
+                    let pct = (ratio * 100.0) as u64;
+
+                    let bar_width = 20usize.min(available_width / 3);
+                    let filled = (ratio * bar_width as f64) as usize;
+                    let empty = bar_width.saturating_sub(filled);
+                    let bar = format!(
+                        "{}{}",
+                        "█".repeat(filled),
+                        "░".repeat(empty),
+                    );
+
+                    let line = Line::from(vec![
+                        Span::styled(format!("  {}", dl.app_name), theme::value()),
+                        Span::styled("  ", theme::label()),
+                        Span::styled(bar, theme::progress_gauge()),
+                        Span::styled(
+                            format!(
+                                "  {} / {} ({}%)",
+                                format_bytes(dl.progress),
+                                format_bytes(dl.total),
+                                pct
+                            ),
+                            theme::label(),
+                        ),
+                    ]);
+
+                    ListItem::new(line)
+                }
+                DownloadStage::Failed => {
+                    let header = Line::from(vec![
+                        Span::styled(format!("  {}", dl.app_name), theme::value()),
+                        Span::styled(" — ", theme::label()),
+                        Span::styled("Failed", theme::error_style()),
+                    ]);
+                    if let Some(ref err) = dl.error {
+                        ListItem::new(vec![
+                            header,
+                            Line::from(Span::styled(
+                                format!("  {err}"),
+                                theme::error_style(),
+                            )),
+                        ])
+                    } else {
+                        ListItem::new(header)
+                    }
+                }
+                _ => {
+                    let status_style = match dl.stage {
+                        DownloadStage::Complete => theme::success_style(),
+                        DownloadStage::Downloading
+                        | DownloadStage::Purchasing
+                        | DownloadStage::Patching => theme::warning_style(),
+                        DownloadStage::Queued | DownloadStage::Cancelled => theme::label(),
+                        _ => theme::label(),
+                    };
+
+                    let line = Line::from(vec![
+                        Span::styled(format!("  {}", dl.app_name), theme::value()),
+                        Span::styled(" — ", theme::label()),
+                        Span::styled(dl.stage.to_string(), status_style),
+                    ]);
+                    ListItem::new(line)
+                }
+            }
+        })
+        .collect();
+
+    let list = List::new(items)
+        .highlight_style(theme::table_selected())
+        .highlight_symbol(" ");
+
+    f.render_stateful_widget(list, area, &mut app.download_list_state);
+}

--- a/crates/ipatool-cli/src/tui/tabs/download.rs
+++ b/crates/ipatool-cli/src/tui/tabs/download.rs
@@ -41,11 +41,7 @@ pub fn render(f: &mut Frame, app: &mut App_, area: Rect) {
                     let bar_width = 20usize.min(available_width / 3);
                     let filled = (ratio * bar_width as f64) as usize;
                     let empty = bar_width.saturating_sub(filled);
-                    let bar = format!(
-                        "{}{}",
-                        "█".repeat(filled),
-                        "░".repeat(empty),
-                    );
+                    let bar = format!("{}{}", "█".repeat(filled), "░".repeat(empty),);
 
                     let line = Line::from(vec![
                         Span::styled(format!("  {}", dl.app_name), theme::value()),
@@ -73,10 +69,7 @@ pub fn render(f: &mut Frame, app: &mut App_, area: Rect) {
                     if let Some(ref err) = dl.error {
                         ListItem::new(vec![
                             header,
-                            Line::from(Span::styled(
-                                format!("  {err}"),
-                                theme::error_style(),
-                            )),
+                            Line::from(Span::styled(format!("  {err}"), theme::error_style())),
                         ])
                     } else {
                         ListItem::new(header)

--- a/crates/ipatool-cli/src/tui/tabs/library.rs
+++ b/crates/ipatool-cli/src/tui/tabs/library.rs
@@ -1,0 +1,42 @@
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Paragraph};
+
+use crate::tui::app::App_;
+use crate::tui::theme;
+
+pub fn render(f: &mut Frame, app: &mut App_, area: Rect) {
+    let bg = Block::default().style(theme::base());
+    f.render_widget(bg, area);
+
+    let text = if app.account.is_some() {
+        vec![
+            Line::from(""),
+            Line::from(""),
+            Line::from(Span::styled("  Library", theme::title())),
+            Line::from(""),
+            Line::from(Span::styled(
+                "  Purchase history API not yet implemented.",
+                theme::label(),
+            )),
+            Line::from(Span::styled(
+                "  Use Search tab to find and download apps.",
+                theme::label(),
+            )),
+        ]
+    } else {
+        vec![
+            Line::from(""),
+            Line::from(""),
+            Line::from(Span::styled("  Library", theme::title())),
+            Line::from(""),
+            Line::from(Span::styled(
+                "  Log in on the Account tab to view your library.",
+                theme::label(),
+            )),
+        ]
+    };
+
+    f.render_widget(Paragraph::new(text), area);
+}

--- a/crates/ipatool-cli/src/tui/tabs/mod.rs
+++ b/crates/ipatool-cli/src/tui/tabs/mod.rs
@@ -1,0 +1,18 @@
+pub mod account;
+pub mod download;
+pub mod library;
+pub mod search;
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+
+use crate::tui::app::{ActiveTab, App_};
+
+pub fn render_tab(f: &mut Frame, app: &mut App_, area: Rect) {
+    match app.active_tab {
+        ActiveTab::Search => search::render(f, app, area),
+        ActiveTab::Library => library::render(f, app, area),
+        ActiveTab::Downloads => download::render(f, app, area),
+        ActiveTab::Account => account::render(f, app, area),
+    }
+}

--- a/crates/ipatool-cli/src/tui/tabs/search.rs
+++ b/crates/ipatool-cli/src/tui/tabs/search.rs
@@ -1,0 +1,236 @@
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, Wrap};
+
+use crate::tui::app::{App_, InputMode};
+use crate::tui::format_bytes;
+use crate::tui::theme;
+
+pub fn render(f: &mut Frame, app: &mut App_, area: Rect) {
+    let bg = Block::default().style(theme::base());
+    f.render_widget(bg, area);
+
+    let chunks = Layout::vertical([Constraint::Length(2), Constraint::Min(5)]).split(area);
+
+    render_search_bar(f, app, chunks[0]);
+    render_content(f, app, chunks[1]);
+}
+
+fn render_search_bar(f: &mut Frame, app: &App_, area: Rect) {
+    let is_active = app.input_mode == InputMode::SearchInput;
+
+    let input_text = app.search_input.value();
+    let display = if input_text.is_empty() && !is_active {
+        Line::from(Span::styled(
+            "  Search apps... (press /)",
+            theme::input_placeholder(),
+        ))
+    } else {
+        Line::from(vec![
+            Span::styled("  ", theme::label()),
+            Span::styled(input_text, theme::input_active()),
+        ])
+    };
+
+    let border_style = if is_active {
+        theme::border_active()
+    } else {
+        theme::border_dim()
+    };
+
+    let input = Paragraph::new(display).block(
+        Block::default()
+            .borders(Borders::BOTTOM)
+            .border_style(border_style),
+    );
+    f.render_widget(input, area);
+
+    if is_active {
+        let cursor_x = area.x + app.search_input.visual_cursor() as u16 + 3;
+        let cursor_y = area.y;
+        f.set_cursor_position((cursor_x, cursor_y));
+    }
+}
+
+fn render_content(f: &mut Frame, app: &mut App_, area: Rect) {
+    if app.search_results.is_empty() {
+        let msg = if app.is_loading {
+            vec![
+                Line::from(""),
+                Line::from(""),
+                Line::from(Span::styled("  Searching...", theme::warning_style())),
+            ]
+        } else {
+            vec![
+                Line::from(""),
+                Line::from(""),
+                Line::from(""),
+                Line::from(Span::styled("  ipatool", theme::title())),
+                Line::from(""),
+                Line::from(Span::styled(
+                    "  Press / to search for iOS apps",
+                    theme::label(),
+                )),
+                Line::from(Span::styled(
+                    "  Then d to download, p to purchase",
+                    theme::label(),
+                )),
+            ]
+        };
+        let p = Paragraph::new(msg).alignment(Alignment::Left);
+        f.render_widget(p, area);
+        return;
+    }
+
+    let chunks =
+        Layout::horizontal([Constraint::Percentage(60), Constraint::Percentage(40)]).split(area);
+
+    render_table(f, app, chunks[0]);
+    render_detail(f, app, chunks[1]);
+}
+
+fn render_table(f: &mut Frame, app: &mut App_, area: Rect) {
+    let header = Row::new(vec![
+        Cell::from("  Name"),
+        Cell::from("Bundle ID"),
+        Cell::from("Ver"),
+        Cell::from("Price"),
+    ])
+    .style(theme::table_header())
+    .height(1);
+
+    let rows: Vec<Row> = app
+        .search_results
+        .iter()
+        .map(|a| {
+            let price = if a.price == 0.0 {
+                "Free".to_string()
+            } else {
+                format!("${:.2}", a.price)
+            };
+            Row::new(vec![
+                Cell::from(format!("  {}", a.name)),
+                Cell::from(a.bundle_id.clone()),
+                Cell::from(a.version.clone().unwrap_or_default()),
+                Cell::from(price),
+            ])
+        })
+        .collect();
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Percentage(35),
+            Constraint::Percentage(35),
+            Constraint::Percentage(15),
+            Constraint::Percentage(15),
+        ],
+    )
+    .header(header)
+    .row_highlight_style(theme::table_selected())
+    .highlight_symbol(" > ");
+
+    f.render_stateful_widget(table, area, &mut app.search_table_state);
+}
+
+fn render_detail(f: &mut Frame, app: &App_, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::LEFT)
+        .border_style(theme::border_dim());
+
+    let Some(selected) = &app.selected_detail else {
+        let p = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled("  Select an app", theme::label())),
+        ])
+        .block(block);
+        f.render_widget(p, area);
+        return;
+    };
+
+    let price = if selected.price == 0.0 {
+        "Free".to_string()
+    } else {
+        format!("${:.2}", selected.price)
+    };
+
+    let artist = selected
+        .extra
+        .get("artistName")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Unknown");
+
+    let genre = selected
+        .extra
+        .get("primaryGenreName")
+        .and_then(|v| v.as_str())
+        .unwrap_or("—");
+
+    let rating = selected
+        .extra
+        .get("averageUserRating")
+        .and_then(|v| v.as_f64())
+        .map(|r| format!("{r:.1}"))
+        .unwrap_or_else(|| "—".to_string());
+
+    let size = selected
+        .extra
+        .get("fileSizeBytes")
+        .and_then(|v| v.as_str().or_else(|| v.as_u64().map(|_| "")))
+        .and_then(|s| {
+            if s.is_empty() {
+                selected
+                    .extra
+                    .get("fileSizeBytes")
+                    .and_then(|v| v.as_u64())
+                    .map(format_bytes)
+            } else {
+                s.parse::<u64>().ok().map(format_bytes)
+            }
+        })
+        .unwrap_or_else(|| "—".to_string());
+
+    let app_id_str = selected.id.to_string();
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(format!("  {}", selected.name), theme::title())),
+        Line::from(Span::styled(format!("  {artist}"), theme::label())),
+        Line::from(""),
+        detail_line("  Bundle", &selected.bundle_id),
+        detail_line("  Version", selected.version.as_deref().unwrap_or("—")),
+        detail_line("  ID", &app_id_str),
+        detail_line("  Price", &price),
+        detail_line("  Genre", genre),
+        detail_line("  Rating", &rating),
+        detail_line("  Size", &size),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                "  d",
+                Style::default()
+                    .fg(theme::ACCENT)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" download  ", theme::label()),
+            Span::styled(
+                "p",
+                Style::default()
+                    .fg(theme::ACCENT)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" purchase", theme::label()),
+        ]),
+    ];
+
+    let p = Paragraph::new(lines).block(block).wrap(Wrap { trim: true });
+    f.render_widget(p, area);
+}
+
+fn detail_line<'a>(label: &'a str, value: &'a str) -> Line<'a> {
+    Line::from(vec![
+        Span::styled(format!("{label}: "), theme::label()),
+        Span::styled(value, theme::value()),
+    ])
+}

--- a/crates/ipatool-cli/src/tui/theme.rs
+++ b/crates/ipatool-cli/src/tui/theme.rs
@@ -1,0 +1,101 @@
+use ratatui::style::{Color, Modifier, Style};
+
+pub const BG_BASE: Color = Color::Rgb(0x1A, 0x1B, 0x26);
+pub const BG_SURFACE: Color = Color::Rgb(0x24, 0x25, 0x35);
+pub const BG_OVERLAY: Color = Color::Rgb(0x2F, 0x30, 0x44);
+
+pub const FG: Color = Color::Rgb(0xC8, 0xC8, 0xD4);
+pub const FG_DIM: Color = Color::Rgb(0x6C, 0x6E, 0x7E);
+pub const FG_BRIGHT: Color = Color::Rgb(0xE8, 0xE8, 0xF0);
+
+pub const ACCENT: Color = Color::Rgb(0x7C, 0x6B, 0xFF);
+pub const SUCCESS: Color = Color::Rgb(0x12, 0xC7, 0x8F);
+pub const WARNING: Color = Color::Rgb(0xE8, 0xC5, 0x47);
+pub const ERROR: Color = Color::Rgb(0xFF, 0x57, 0x7D);
+pub const HIGHLIGHT: Color = Color::Rgb(0xFF, 0x4F, 0xBF);
+
+pub fn base() -> Style {
+    Style::default().bg(BG_BASE).fg(FG)
+}
+
+pub fn surface() -> Style {
+    Style::default().bg(BG_SURFACE).fg(FG)
+}
+
+pub fn tab_active() -> Style {
+    Style::default()
+        .bg(ACCENT)
+        .fg(FG_BRIGHT)
+        .add_modifier(Modifier::BOLD)
+}
+
+pub fn tab_inactive() -> Style {
+    Style::default().bg(BG_BASE).fg(FG_DIM)
+}
+
+pub fn table_header() -> Style {
+    Style::default().fg(ACCENT).add_modifier(Modifier::BOLD)
+}
+
+pub fn table_selected() -> Style {
+    Style::default().bg(BG_OVERLAY).fg(HIGHLIGHT)
+}
+
+pub fn status_bar() -> Style {
+    Style::default().bg(BG_OVERLAY).fg(FG)
+}
+
+pub fn status_key() -> Style {
+    Style::default()
+        .bg(BG_OVERLAY)
+        .fg(ACCENT)
+        .add_modifier(Modifier::BOLD)
+}
+
+pub fn status_desc() -> Style {
+    Style::default().bg(BG_OVERLAY).fg(FG_DIM)
+}
+
+pub fn input_active() -> Style {
+    Style::default().bg(BG_SURFACE).fg(FG_BRIGHT)
+}
+
+pub fn input_placeholder() -> Style {
+    Style::default().fg(FG_DIM)
+}
+
+pub fn border_active() -> Style {
+    Style::default().fg(ACCENT)
+}
+
+pub fn border_dim() -> Style {
+    Style::default().fg(Color::Rgb(0x3A, 0x3B, 0x50))
+}
+
+pub fn progress_gauge() -> Style {
+    Style::default().fg(SUCCESS).bg(BG_SURFACE)
+}
+
+pub fn error_style() -> Style {
+    Style::default().fg(ERROR)
+}
+
+pub fn success_style() -> Style {
+    Style::default().fg(SUCCESS)
+}
+
+pub fn warning_style() -> Style {
+    Style::default().fg(WARNING)
+}
+
+pub fn label() -> Style {
+    Style::default().fg(FG_DIM)
+}
+
+pub fn value() -> Style {
+    Style::default().fg(FG)
+}
+
+pub fn title() -> Style {
+    Style::default().fg(FG_BRIGHT).add_modifier(Modifier::BOLD)
+}

--- a/crates/ipatool-core/src/api/auth.rs
+++ b/crates/ipatool-core/src/api/auth.rs
@@ -130,6 +130,7 @@ pub async fn login(
             name,
             store_front: sf,
             pod,
+            password: None,
         });
     }
 }

--- a/crates/ipatool-core/src/api/download.rs
+++ b/crates/ipatool-core/src/api/download.rs
@@ -85,6 +85,7 @@ async fn try_get_download_info(
         "guid".into(),
         plist::Value::String(client.guid().to_string()),
     );
+    body.insert("creditDisplay".into(), plist::Value::String(String::new()));
 
     if let Some(vid) = external_version_id {
         body.insert(
@@ -108,11 +109,9 @@ async fn try_get_download_info(
     let resp = client
         .http()
         .post(&url)
-        .header("Content-Type", "application/x-www-form-urlencoded")
+        .header("Content-Type", "application/x-apple-plist")
         .header("iCloud-DSID", &account.directory_services_id)
         .header("X-Dsid", &account.directory_services_id)
-        .header("X-Apple-Store-Front", &account.store_front)
-        .header("X-Token", &account.password_token)
         .body(body_bytes)
         .send()
         .await?;
@@ -129,20 +128,49 @@ async fn try_get_download_info(
     let dict: HashMap<String, plist::Value> =
         crate::client::plist_xml::parse_plist_response(&resp_body)?;
 
-    if let Some(err) = StoreError::from_plist_dict(&dict) {
-        return Err(ClientError::Store(err));
-    }
+    download_item_from_response_dict(&dict)
+}
 
-    let song_list = dict
-        .get("songList")
-        .and_then(|v| v.as_array())
-        .ok_or_else(|| ClientError::UnexpectedResponse("missing songList".into()))?;
+fn download_item_from_response_dict(
+    dict: &HashMap<String, plist::Value>,
+) -> Result<DownloadItem, ClientError> {
+    match StoreError::from_plist_dict(dict) {
+        Some(StoreError::LicenseAlreadyExists) => {
+            if let Some(item) = download_item_from_dict(dict)? {
+                Ok(item)
+            } else {
+                Err(ClientError::Store(StoreError::PasswordTokenExpired))
+            }
+        }
+        Some(err) => Err(ClientError::Store(err)),
+        None => {
+            if let Some(item) = download_item_from_dict(dict)? {
+                Ok(item)
+            } else {
+                Err(ClientError::UnexpectedResponse("missing songList".into()))
+            }
+        }
+    }
+}
+
+fn download_item_from_dict(
+    dict: &HashMap<String, plist::Value>,
+) -> Result<Option<DownloadItem>, ClientError> {
+    let Some(song_list) = dict.get("songList") else {
+        return Ok(None);
+    };
+
+    let song_list = song_list
+        .as_array()
+        .ok_or_else(|| ClientError::UnexpectedResponse("invalid songList".into()))?;
 
     let first = song_list
         .first()
         .ok_or_else(|| ClientError::UnexpectedResponse("empty songList".into()))?;
 
-    plist::from_value(first).map_err(ClientError::PlistDe)
+    plist::from_value(first)
+        .map(Some)
+        .map_err(ClientError::PlistDe)
 }
 
 pub async fn download_file(
@@ -239,4 +267,61 @@ fn download_url(account: &Account, guid: &str) -> String {
         None => "buy.itunes.apple.com".to_string(),
     };
     format!("https://{host}/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct?guid={guid}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_download_item() -> plist::Value {
+        let mut sinf = plist::Dictionary::new();
+        sinf.insert("id".into(), plist::Value::Integer(1.into()));
+        sinf.insert("sinf".into(), plist::Value::Data(vec![1, 2, 3]));
+
+        let mut item = plist::Dictionary::new();
+        item.insert(
+            "URL".into(),
+            plist::Value::String("https://example.invalid/app.ipa".into()),
+        );
+        item.insert(
+            "sinfs".into(),
+            plist::Value::Array(vec![plist::Value::Dictionary(sinf)]),
+        );
+
+        plist::Value::Dictionary(item)
+    }
+
+    #[test]
+    fn download_item_wins_over_license_already_exists_marker() {
+        let mut dict = HashMap::new();
+        dict.insert("failureType".into(), plist::Value::String("5002".into()));
+        dict.insert(
+            "customerMessage".into(),
+            plist::Value::String("license already exists".into()),
+        );
+        dict.insert(
+            "songList".into(),
+            plist::Value::Array(vec![sample_download_item()]),
+        );
+
+        let item = download_item_from_response_dict(&dict).unwrap();
+
+        assert_eq!(item.url, "https://example.invalid/app.ipa");
+        assert_eq!(item.sinfs[0].id, 1);
+        assert_eq!(item.sinfs[0].sinf, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn bare_license_already_exists_requires_reauth_for_download() {
+        let mut dict = HashMap::new();
+        dict.insert("failureType".into(), plist::Value::String("5002".into()));
+        dict.insert(
+            "customerMessage".into(),
+            plist::Value::String("license already exists".into()),
+        );
+
+        let err = download_item_from_response_dict(&dict).unwrap_err();
+
+        assert!(err.is_token_expired());
+    }
 }

--- a/crates/ipatool-core/src/api/download.rs
+++ b/crates/ipatool-core/src/api/download.rs
@@ -41,7 +41,34 @@ mod serde_bytes {
     }
 }
 
+const MAX_DOWNLOAD_ATTEMPTS: u32 = 3;
+
 pub async fn get_download_info(
+    client: &AppleClient,
+    app_id: i64,
+    account: &Account,
+    external_version_id: Option<&str>,
+) -> Result<DownloadItem, ClientError> {
+    for attempt in 0..MAX_DOWNLOAD_ATTEMPTS {
+        match try_get_download_info(client, app_id, account, external_version_id).await {
+            Err(ClientError::Store(StoreError::TemporarilyUnavailable))
+                if attempt + 1 < MAX_DOWNLOAD_ATTEMPTS =>
+            {
+                let delay = 5 * (attempt as u64 + 1);
+                tracing::warn!(
+                    attempt = attempt + 1,
+                    delay,
+                    "temporarily unavailable, retrying"
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
+            }
+            other => return other,
+        }
+    }
+    Err(ClientError::Store(StoreError::TemporarilyUnavailable))
+}
+
+async fn try_get_download_info(
     client: &AppleClient,
     app_id: i64,
     account: &Account,

--- a/crates/ipatool-core/src/api/mod.rs
+++ b/crates/ipatool-core/src/api/mod.rs
@@ -3,5 +3,6 @@ pub mod bag;
 pub mod download;
 pub mod lookup;
 pub mod purchase;
+pub mod reauth;
 pub mod search;
 pub mod versions;

--- a/crates/ipatool-core/src/api/purchase.rs
+++ b/crates/ipatool-core/src/api/purchase.rs
@@ -54,6 +54,10 @@ async fn try_purchase(
         plist::Value::String("true".into()),
     );
     body.insert(
+        "hasDoneAgeCheck".into(),
+        plist::Value::String("true".into()),
+    );
+    body.insert(
         "buyWithoutAuthorization".into(),
         plist::Value::String("true".into()),
     );
@@ -92,7 +96,7 @@ async fn try_purchase(
     let resp = client
         .http()
         .post(&url)
-        .header("Content-Type", "application/x-www-form-urlencoded")
+        .header("Content-Type", "application/x-apple-plist")
         .header("iCloud-DSID", &account.directory_services_id)
         .header("X-Dsid", &account.directory_services_id)
         .header("X-Apple-Store-Front", &account.store_front)

--- a/crates/ipatool-core/src/api/purchase.rs
+++ b/crates/ipatool-core/src/api/purchase.rs
@@ -4,18 +4,39 @@ use crate::client::AppleClient;
 use crate::error::{ClientError, StoreError};
 use crate::model::Account;
 
+const MAX_PURCHASE_ATTEMPTS: u32 = 3;
+
 pub async fn purchase(
     client: &AppleClient,
     app_id: i64,
     account: &Account,
 ) -> Result<(), ClientError> {
-    match try_purchase(client, app_id, account, "STDQ").await {
-        Err(ClientError::Store(StoreError::TemporarilyUnavailable)) => {
-            tracing::info!("STDQ unavailable, trying GAME pricing");
-            try_purchase(client, app_id, account, "GAME").await
+    for attempt in 0..MAX_PURCHASE_ATTEMPTS {
+        let result = match try_purchase(client, app_id, account, "STDQ").await {
+            Err(ClientError::Store(StoreError::TemporarilyUnavailable)) => {
+                tracing::info!("STDQ unavailable, trying GAME pricing");
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                try_purchase(client, app_id, account, "GAME").await
+            }
+            other => other,
+        };
+
+        match result {
+            Err(ClientError::Store(StoreError::TemporarilyUnavailable))
+                if attempt + 1 < MAX_PURCHASE_ATTEMPTS =>
+            {
+                let delay = 5 * (attempt as u64 + 1);
+                tracing::warn!(
+                    attempt = attempt + 1,
+                    delay,
+                    "temporarily unavailable, retrying"
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
+            }
+            other => return other,
         }
-        other => other,
     }
+    Err(ClientError::Store(StoreError::TemporarilyUnavailable))
 }
 
 async fn try_purchase(
@@ -81,6 +102,12 @@ async fn try_purchase(
         .await?;
 
     let resp_body = resp.bytes().await?;
+    tracing::debug!(
+        len = resp_body.len(),
+        preview = %String::from_utf8_lossy(&resp_body[..resp_body.len().min(500)]),
+        pricing = pricing_parameters,
+        "purchase response body"
+    );
     let dict: HashMap<String, plist::Value> =
         crate::client::plist_xml::parse_plist_response(&resp_body)?;
 

--- a/crates/ipatool-core/src/api/reauth.rs
+++ b/crates/ipatool-core/src/api/reauth.rs
@@ -1,0 +1,23 @@
+use crate::client::AppleClient;
+use crate::error::ClientError;
+use crate::model::Account;
+
+pub async fn reauthenticate(
+    client: &AppleClient,
+    account: &Account,
+) -> Result<Account, ClientError> {
+    let password = account
+        .password
+        .as_deref()
+        .ok_or_else(|| ClientError::UnexpectedResponse("no stored password for re-auth".into()))?;
+
+    let auth_url = super::bag::fetch_auth_endpoint(client).await?;
+
+    tracing::info!("re-authenticating as {}", account.email);
+
+    let mut new_account =
+        super::auth::login(client, &account.email, password, None, &auth_url).await?;
+
+    new_account.password = account.password.clone();
+    Ok(new_account)
+}

--- a/crates/ipatool-core/src/error.rs
+++ b/crates/ipatool-core/src/error.rs
@@ -12,6 +12,8 @@ pub enum StoreError {
     LicenseNotFound,
     #[error("temporarily unavailable")]
     TemporarilyUnavailable,
+    #[error("purchase couldn't be completed")]
+    PurchaseFailed,
     #[error("license already exists")]
     LicenseAlreadyExists,
     #[error("device verification failed")]
@@ -33,7 +35,15 @@ impl StoreError {
             "2034" => Self::PasswordTokenExpired,
             "2042" => Self::SignInRequired,
             "9610" => Self::LicenseNotFound,
-            "2059" => Self::TemporarilyUnavailable,
+            // TODO: substring matching on customerMessage is locale-dependent; find a more stable signal
+            "2059" => {
+                let msg = customer_message.unwrap_or("");
+                if msg.contains("completed") || msg.contains("not available") {
+                    Self::PurchaseFailed
+                } else {
+                    Self::TemporarilyUnavailable
+                }
+            }
             "5002" => Self::LicenseAlreadyExists,
             "1008" => Self::DeviceVerificationFailed,
             "" => {
@@ -58,6 +68,13 @@ impl StoreError {
 
     pub fn is_retryable(&self) -> bool {
         matches!(self, Self::InvalidCredentials)
+    }
+
+    pub fn is_token_expired(&self) -> bool {
+        matches!(
+            self,
+            Self::PasswordTokenExpired | Self::SignInRequired | Self::DeviceVerificationFailed
+        )
     }
 
     pub fn from_plist_dict(dict: &HashMap<String, plist::Value>) -> Option<Self> {
@@ -99,6 +116,20 @@ pub enum ClientError {
     MissingHeader(String),
     #[error("unexpected response: {0}")]
     UnexpectedResponse(String),
+}
+
+impl ClientError {
+    pub fn is_token_expired(&self) -> bool {
+        matches!(self, Self::Store(e) if e.is_token_expired())
+    }
+
+    pub fn is_license_not_found(&self) -> bool {
+        matches!(self, Self::Store(StoreError::LicenseNotFound))
+    }
+
+    pub fn is_license_already_exists(&self) -> bool {
+        matches!(self, Self::Store(StoreError::LicenseAlreadyExists))
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/ipatool-core/src/model/account.rs
+++ b/crates/ipatool-core/src/model/account.rs
@@ -8,4 +8,6 @@ pub struct Account {
     pub name: String,
     pub store_front: String,
     pub pod: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
 }


### PR DESCRIPTION
## Summary
- Add an interactive terminal UI (ratatui + crossterm) launched by running `ipatool` with no subcommand, with tabbed views for search, downloads, library, and account management (including 2FA login)
- Add automatic token refresh / re-authentication when sessions expire during purchase and download flows
- Add retry with backoff for `TemporarilyUnavailable` errors in both purchase and download APIs
- Distinguish `PurchaseFailed` from `TemporarilyUnavailable` on store error code 2059

## Test plan
- [x] Run `ipatool` with no args — TUI launches with tab navigation
- [x] Log in via Account tab (with and without 2FA)
- [x] Search for an app, browse results, view detail panel
- [x] Download and purchase from the TUI
- [x] Verify CLI subcommands (`auth login`, `download`, `purchase`, `search`) still work as before
- [x] Verify expired-token re-auth by letting a session expire and retrying a download