### PR TITLE
fix: auth 2FA login handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The UI is built with [ratatui](https://ratatui.rs/) and [crossterm](https://gith
 Log in with your Apple ID. Two-factor authentication is supported.
 
 ```bash
-# Interactive login
+# Interactive login (prompts for a 2FA code if Apple requires one)
 ipatool auth login --email your@apple.id --password 'password'
 
 # With 2FA code

--- a/crates/ipatool-cli/src/commands/auth.rs
+++ b/crates/ipatool-cli/src/commands/auth.rs
@@ -3,6 +3,7 @@ use anyhow::{Context, Result, bail};
 use ipatool_core::api;
 use ipatool_core::client::AppleClient;
 use ipatool_core::credential;
+use ipatool_core::error::{ClientError, StoreError};
 
 use crate::output::{OutputFormat, print_account};
 
@@ -30,9 +31,41 @@ pub async fn login(
 
     tracing::info!(url = %auth_url, "using auth endpoint");
 
-    let mut account = api::auth::login(client, email, &password, auth_code, &auth_url)
-        .await
-        .context("login failed")?;
+    let mut account = match api::auth::login(client, email, &password, auth_code, &auth_url).await {
+        Ok(account) => account,
+        Err(ClientError::Store(StoreError::AuthCodeRequired))
+            if auth_code.is_none() && !non_interactive =>
+        {
+            eprintln!(
+                "Apple rejected the login. If Apple is showing a two-factor code, enter it now; otherwise press Enter and check your password."
+            );
+            let auth_code = rpassword::prompt_password("Two-factor code (optional): ")
+                .context("failed to read 2FA code")?;
+            let auth_code = auth_code.trim();
+            if auth_code.is_empty() {
+                bail!(
+                    "login rejected; check your password, or rerun with --auth-code <code> if Apple is asking for two-factor authentication"
+                );
+            }
+
+            match api::auth::login(client, email, &password, Some(auth_code), &auth_url).await {
+                Ok(account) => account,
+                Err(ClientError::Store(StoreError::AuthCodeRequired)) => {
+                    bail!("login rejected; check your password and 2FA code")
+                }
+                Err(e) => return Err(e).context("login failed"),
+            }
+        }
+        Err(ClientError::Store(StoreError::AuthCodeRequired)) if auth_code.is_none() => {
+            bail!(
+                "login rejected; check your password, or rerun with --auth-code <code> if Apple is asking for two-factor authentication"
+            )
+        }
+        Err(ClientError::Store(StoreError::AuthCodeRequired)) => {
+            bail!("login rejected; check your password and 2FA code")
+        }
+        Err(e) => return Err(e).context("login failed"),
+    };
 
     account.password = Some(password);
     credential::store_account(&account).context("failed to store credentials")?;

--- a/crates/ipatool-cli/src/tui/action.rs
+++ b/crates/ipatool-cli/src/tui/action.rs
@@ -36,7 +36,6 @@ pub enum Action {
     ClearFinishedDownloads,
 
     SubmitLogin,
-    LoginNeedsAuthCode,
     LoginSuccess(Account),
     LoginError(String),
     Logout,

--- a/crates/ipatool-cli/src/tui/app.rs
+++ b/crates/ipatool-cli/src/tui/app.rs
@@ -106,7 +106,6 @@ pub struct App_ {
     pub login_email: Input,
     pub login_password: String,
     pub login_auth_code: Input,
-    pub login_needs_auth_code: bool,
     pub login_error: Option<String>,
 
     pub client: Arc<Mutex<AppleClient>>,
@@ -155,7 +154,6 @@ impl App_ {
             login_email: Input::default(),
             login_password: String::new(),
             login_auth_code: Input::default(),
-            login_needs_auth_code: false,
             login_error: None,
 
             client,

--- a/crates/ipatool-cli/src/tui/handler.rs
+++ b/crates/ipatool-cli/src/tui/handler.rs
@@ -180,7 +180,6 @@ fn handle_account_normal(app: &mut App_, key: KeyEvent) {
                 app.input_mode = InputMode::LoginEmail;
                 app.login_error = None;
                 app.login_auth_code = tui_input::Input::default();
-                app.login_needs_auth_code = false;
             }
         }
         KeyCode::Char('r') if app.account.is_some() => {
@@ -224,14 +223,10 @@ fn handle_login_email(app: &mut App_, key: KeyEvent) {
 fn handle_login_password(app: &mut App_, key: KeyEvent) {
     match key.code {
         KeyCode::Enter => {
-            if app.login_needs_auth_code {
-                app.input_mode = InputMode::LoginAuthCode;
-            } else {
-                app.input_mode = InputMode::Normal;
-                app.action_tx.send(Action::SubmitLogin).ok();
-            }
+            app.input_mode = InputMode::Normal;
+            app.action_tx.send(Action::SubmitLogin).ok();
         }
-        KeyCode::Tab if app.login_needs_auth_code => {
+        KeyCode::Tab => {
             app.input_mode = InputMode::LoginAuthCode;
         }
         KeyCode::Esc => {
@@ -252,6 +247,12 @@ fn handle_login_auth_code(app: &mut App_, key: KeyEvent) {
         KeyCode::Enter => {
             app.input_mode = InputMode::Normal;
             app.action_tx.send(Action::SubmitLogin).ok();
+        }
+        KeyCode::Tab => {
+            app.input_mode = InputMode::LoginEmail;
+        }
+        KeyCode::BackTab => {
+            app.input_mode = InputMode::LoginPassword;
         }
         KeyCode::Esc => {
             app.input_mode = InputMode::Normal;

--- a/crates/ipatool-cli/src/tui/mod.rs
+++ b/crates/ipatool-cli/src/tui/mod.rs
@@ -278,17 +278,17 @@ async fn process_action(app: &mut App_, action: Action) {
                 return;
             }
 
-            let auth_code = if app.login_needs_auth_code {
+            let auth_code = {
                 let code = app.login_auth_code.value().trim().to_string();
-                if code.is_empty() {
-                    app.input_mode = InputMode::LoginAuthCode;
-                    app.login_error = Some("Two-factor authentication code required".to_string());
-                    return;
-                }
-                Some(code)
-            } else {
-                None
+                if code.is_empty() { None } else { Some(code) }
             };
+
+            let auth_code_hint = if auth_code.is_some() {
+                "login rejected; check your password and 2FA code"
+            } else {
+                "login rejected; check your password, or enter a 2FA code if Apple requested one"
+            }
+            .to_string();
 
             app.status_message = "Logging in...".to_string();
             app.login_error = None;
@@ -344,20 +344,13 @@ async fn process_action(app: &mut App_, action: Action) {
                             )
                         ) =>
                     {
-                        tx.send(Action::LoginNeedsAuthCode).ok();
+                        tx.send(Action::LoginError(auth_code_hint)).ok();
                     }
                     Err(e) => {
                         tx.send(Action::LoginError(e.to_string())).ok();
                     }
                 }
             });
-        }
-        Action::LoginNeedsAuthCode => {
-            app.login_needs_auth_code = true;
-            app.login_auth_code = tui_input::Input::default();
-            app.input_mode = InputMode::LoginAuthCode;
-            app.login_error = Some("Two-factor authentication code required".to_string());
-            app.status_message = "Enter two-factor authentication code".to_string();
         }
         Action::LoginSuccess(account) => {
             if let Some(country) =
@@ -368,11 +361,12 @@ async fn process_action(app: &mut App_, action: Action) {
             app.account = Some(account);
             app.login_password.clear();
             app.login_auth_code = tui_input::Input::default();
-            app.login_needs_auth_code = false;
             app.status_message = "Logged in successfully".to_string();
         }
         Action::LoginError(err) => {
-            if app.login_needs_auth_code {
+            if app.login_auth_code.value().trim().is_empty() {
+                app.input_mode = InputMode::LoginPassword;
+            } else {
                 app.input_mode = InputMode::LoginAuthCode;
             }
             app.login_error = Some(err.clone());
@@ -387,7 +381,6 @@ async fn process_action(app: &mut App_, action: Action) {
             } else {
                 app.account = None;
                 app.login_auth_code = tui_input::Input::default();
-                app.login_needs_auth_code = false;
                 app.status_message = "Logged out".to_string();
             }
         }

--- a/crates/ipatool-cli/src/tui/tabs/account.rs
+++ b/crates/ipatool-cli/src/tui/tabs/account.rs
@@ -45,33 +45,19 @@ fn render_login_form(f: &mut Frame, app: &App_, area: Rect) {
     let email_active = app.input_mode == InputMode::LoginEmail;
     let pass_active = app.input_mode == InputMode::LoginPassword;
     let auth_code_active = app.input_mode == InputMode::LoginAuthCode;
-    let show_auth_code = app.login_needs_auth_code || auth_code_active;
 
-    let chunks = if show_auth_code {
-        Layout::vertical([
-            Constraint::Length(1),
-            Constraint::Length(1),
-            Constraint::Length(2),
-            Constraint::Length(1),
-            Constraint::Length(2),
-            Constraint::Length(1),
-            Constraint::Length(2),
-            Constraint::Length(1),
-            Constraint::Min(1),
-        ])
-        .split(area)
-    } else {
-        Layout::vertical([
-            Constraint::Length(1),
-            Constraint::Length(1),
-            Constraint::Length(2),
-            Constraint::Length(1),
-            Constraint::Length(2),
-            Constraint::Length(1),
-            Constraint::Min(1),
-        ])
-        .split(area)
-    };
+    let chunks = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(2),
+        Constraint::Length(1),
+        Constraint::Length(2),
+        Constraint::Length(1),
+        Constraint::Length(2),
+        Constraint::Length(1),
+        Constraint::Min(1),
+    ])
+    .split(area);
 
     f.render_widget(
         Paragraph::new(Span::styled("  Login", theme::title())),
@@ -152,51 +138,43 @@ fn render_login_form(f: &mut Frame, app: &App_, area: Rect) {
         f.set_cursor_position((cx, cy));
     }
 
-    let help_chunk;
-    let footer_chunk;
-
-    if show_auth_code {
-        let auth_code_label_style = if auth_code_active {
-            theme::border_active()
-        } else {
-            theme::label()
-        };
-        f.render_widget(
-            Paragraph::new(Span::styled("  Two-factor code", auth_code_label_style)),
-            chunks[5],
-        );
-
-        let auth_code_text = if app.login_auth_code.value().is_empty() && !auth_code_active {
-            Line::from(Span::styled("  123456", theme::input_placeholder()))
-        } else {
-            Line::from(Span::styled(
-                format!("  {}", app.login_auth_code.value()),
-                theme::input_active(),
-            ))
-        };
-        let auth_code_border = if auth_code_active {
-            theme::border_active()
-        } else {
-            theme::border_dim()
-        };
-        let auth_code = Paragraph::new(auth_code_text).block(
-            Block::default()
-                .borders(Borders::BOTTOM)
-                .border_style(auth_code_border),
-        );
-        f.render_widget(auth_code, chunks[6]);
-
-        if auth_code_active {
-            let cx = chunks[6].x + app.login_auth_code.visual_cursor() as u16 + 3;
-            let cy = chunks[6].y;
-            f.set_cursor_position((cx, cy));
-        }
-
-        help_chunk = chunks[7];
-        footer_chunk = chunks[8];
+    let auth_code_label_style = if auth_code_active {
+        theme::border_active()
     } else {
-        help_chunk = chunks[5];
-        footer_chunk = chunks[6];
+        theme::label()
+    };
+    f.render_widget(
+        Paragraph::new(Span::styled(
+            "  Two-factor code (optional)",
+            auth_code_label_style,
+        )),
+        chunks[5],
+    );
+
+    let auth_code_text = if app.login_auth_code.value().is_empty() && !auth_code_active {
+        Line::from(Span::styled("  123456", theme::input_placeholder()))
+    } else {
+        Line::from(Span::styled(
+            format!("  {}", app.login_auth_code.value()),
+            theme::input_active(),
+        ))
+    };
+    let auth_code_border = if auth_code_active {
+        theme::border_active()
+    } else {
+        theme::border_dim()
+    };
+    let auth_code = Paragraph::new(auth_code_text).block(
+        Block::default()
+            .borders(Borders::BOTTOM)
+            .border_style(auth_code_border),
+    );
+    f.render_widget(auth_code, chunks[6]);
+
+    if auth_code_active {
+        let cx = chunks[6].x + app.login_auth_code.visual_cursor() as u16 + 3;
+        let cy = chunks[6].y;
+        f.set_cursor_position((cx, cy));
     }
 
     let help = if let Some(ref err) = app.login_error {
@@ -216,7 +194,7 @@ fn render_login_form(f: &mut Frame, app: &App_, area: Rect) {
         ]
     };
 
-    f.render_widget(Paragraph::new(help), help_chunk);
+    f.render_widget(Paragraph::new(help), chunks[7]);
 
     f.render_widget(
         Paragraph::new(vec![
@@ -226,7 +204,7 @@ fn render_login_form(f: &mut Frame, app: &App_, area: Rect) {
                 theme::label(),
             )),
         ]),
-        footer_chunk,
+        chunks[8],
     );
 }
 

--- a/crates/ipatool-core/src/api/auth.rs
+++ b/crates/ipatool-core/src/api/auth.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::Duration;
 use url::Url;
 
 use crate::client::AppleClient;
@@ -6,6 +7,8 @@ use crate::error::{ClientError, StoreError};
 use crate::model::Account;
 
 const MAX_ATTEMPTS: u32 = 4;
+const MAX_REDIRECTS: u32 = 5;
+const AUTH_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub async fn login(
     client: &AppleClient,
@@ -20,6 +23,7 @@ pub async fn login(
     };
 
     let mut attempt = 1u32;
+    let mut redirects = 0u32;
     let mut current_url = auth_url.clone();
 
     loop {
@@ -34,6 +38,7 @@ pub async fn login(
             .http()
             .post(current_url.as_str())
             .header("Content-Type", "application/x-apple-plist")
+            .timeout(AUTH_REQUEST_TIMEOUT)
             .body(body_bytes)
             .send()
             .await?;
@@ -44,6 +49,13 @@ pub async fn login(
         if status == reqwest::StatusCode::FOUND
             && let Some(location) = resp.headers().get("location")
         {
+            redirects += 1;
+            if redirects > MAX_REDIRECTS {
+                return Err(ClientError::UnexpectedResponse(
+                    "too many auth redirects".into(),
+                ));
+            }
+
             let new_url = location
                 .to_str()
                 .map_err(|_| ClientError::MissingHeader("location (invalid)".into()))?;

--- a/crates/ipatool-core/src/api/bag.rs
+++ b/crates/ipatool-core/src/api/bag.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
 use url::Url;
 
@@ -6,9 +7,15 @@ use crate::client::AppleClient;
 use crate::error::ClientError;
 
 const BAG_URL: &str = "https://init.itunes.apple.com/bag.xml?ix=5";
+const BAG_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub async fn fetch_auth_endpoint(client: &AppleClient) -> Result<Url, ClientError> {
-    let resp = client.http().get(BAG_URL).send().await?;
+    let resp = client
+        .http()
+        .get(BAG_URL)
+        .timeout(BAG_REQUEST_TIMEOUT)
+        .send()
+        .await?;
     let body = resp.bytes().await?;
 
     let outer: HashMap<String, plist::Value> =

--- a/crates/ipatool-core/src/error.rs
+++ b/crates/ipatool-core/src/error.rs
@@ -18,7 +18,7 @@ pub enum StoreError {
     LicenseAlreadyExists,
     #[error("device verification failed")]
     DeviceVerificationFailed,
-    #[error("2FA code required")]
+    #[error("login rejected; password may be wrong or a 2FA code may be required")]
     AuthCodeRequired,
     #[error("account disabled")]
     AccountDisabled,


### PR DESCRIPTION
## Summary

- Treat Apple's ambiguous `BadLogin` auth response as a login rejection instead of assuming it always means 2FA is required.
- Keep 2FA available in both CLI and TUI without misleading users when the password is wrong.
- Add auth/bag request timeouts and an auth redirect cap so login does not stay stuck at `Logging in...`.

## Root Cause

Apple's auth endpoint can return the same `MZFinance.BadLogin` signal when a 2FA code is needed and when credentials are rejected. The previous UI/CLI path treated that signal as a definite 2FA requirement.

## Validation

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`

Fixes #2
