### PR TITLE
fix: version metadata from IPA Info.plist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,7 @@ version = "0.1.2"
 dependencies = [
  "bytes",
  "cookie_store 0.21.1",
+ "flate2",
  "futures-util",
  "indicatif",
  "keyring",
@@ -1107,6 +1108,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tracing",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1"
 thiserror = "2"
 anyhow = "1"
 tracing = "0.1"
+time = { version = "0.3", features = ["formatting", "parsing"] }
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 crossterm = { version = "0.29", features = ["event-stream"] }
 tui-input = "0.15"

--- a/crates/ipatool-cli/src/commands/download.rs
+++ b/crates/ipatool-cli/src/commands/download.rs
@@ -121,6 +121,7 @@ async fn purchase_for_download(
     match api::purchase::purchase(client, app_id, account).await {
         Ok(()) => Ok(()),
         Err(e) if e.is_token_expired() => {
+            eprintln!("Token expired during purchase, re-authenticating...");
             *account = reauth_or_fail(client, account).await?;
             api::purchase::purchase(client, app_id, account)
                 .await

--- a/crates/ipatool-cli/src/commands/mod.rs
+++ b/crates/ipatool-cli/src/commands/mod.rs
@@ -10,7 +10,6 @@ use ipatool_core::client::AppleClient;
 use ipatool_core::model::Account;
 
 pub async fn reauth_or_fail(client: &AppleClient, account: &Account) -> Result<Account> {
-    eprintln!("Token expired, re-authenticating...");
     let new_account = ipatool_core::api::reauth::reauthenticate(client, account)
         .await
         .context("re-authentication failed")?;

--- a/crates/ipatool-cli/src/commands/purchase.rs
+++ b/crates/ipatool-cli/src/commands/purchase.rs
@@ -23,6 +23,7 @@ pub async fn purchase(
     match api::purchase::purchase(client, app.id, account).await {
         Ok(()) => {}
         Err(e) if e.is_token_expired() => {
+            eprintln!("Token expired, re-authenticating...");
             let new_account = super::reauth_or_fail(client, account).await?;
             api::purchase::purchase(client, app.id, &new_account)
                 .await

--- a/crates/ipatool-cli/src/commands/version.rs
+++ b/crates/ipatool-cli/src/commands/version.rs
@@ -5,7 +5,10 @@ use ipatool_core::client::AppleClient;
 use ipatool_core::model::storefront::country_code_from_store_front;
 use ipatool_core::model::{Account, Platform};
 
+use super::reauth_or_fail;
 use crate::output::{self, OutputFormat};
+
+const MAX_VERSION_ATTEMPTS: u32 = 3;
 
 pub async fn list(
     client: &AppleClient,
@@ -15,14 +18,37 @@ pub async fn list(
     format: OutputFormat,
 ) -> Result<()> {
     let resolved_app_id = resolve_app_id(client, app_id, bundle_identifier, account).await?;
+    let mut account = account.clone();
+    let mut result = None;
+    let mut last_error = None;
 
-    let result = match api::versions::list_versions(client, resolved_app_id, account).await {
-        Ok(result) => result,
-        Err(e) if e.is_license_not_found() => {
-            return Err(license_not_found_error(bundle_identifier));
+    for attempt in 0..MAX_VERSION_ATTEMPTS {
+        match api::versions::list_versions(client, resolved_app_id, &account).await {
+            Ok(versions) => {
+                result = Some(versions);
+                break;
+            }
+            Err(e) if e.is_license_not_found() => {
+                return Err(license_not_found_error(bundle_identifier));
+            }
+            Err(e) if e.is_token_expired() && attempt + 1 < MAX_VERSION_ATTEMPTS => {
+                last_error = Some(e.to_string());
+                eprintln!(
+                    "Token expired, re-authenticating (attempt {})...",
+                    attempt + 1
+                );
+                account = reauth_or_fail(client, &account).await?;
+            }
+            Err(e) => return Err(e).context("failed to list versions"),
         }
-        Err(e) => return Err(e).context("failed to list versions"),
-    };
+    }
+
+    let result = result.with_context(|| {
+        last_error.map_or_else(
+            || "failed to list versions after retries".to_string(),
+            |e| format!("failed to list versions after retries: {e}"),
+        )
+    })?;
 
     match format {
         OutputFormat::Text => {
@@ -60,17 +86,40 @@ pub async fn meta(
     format: OutputFormat,
 ) -> Result<()> {
     let resolved_app_id = resolve_app_id(client, app_id, bundle_identifier, account).await?;
+    let mut account = account.clone();
 
-    let result =
-        match api::versions::get_version_metadata(client, resolved_app_id, account, version_id)
+    let mut result = None;
+    let mut last_error = None;
+
+    for attempt in 0..MAX_VERSION_ATTEMPTS {
+        match api::versions::get_version_metadata(client, resolved_app_id, &account, version_id)
             .await
         {
-            Ok(result) => result,
+            Ok(metadata) => {
+                result = Some(metadata);
+                break;
+            }
             Err(e) if e.is_license_not_found() => {
                 return Err(license_not_found_error(bundle_identifier));
             }
+            Err(e) if e.is_token_expired() && attempt + 1 < MAX_VERSION_ATTEMPTS => {
+                last_error = Some(e.to_string());
+                eprintln!(
+                    "Token expired, re-authenticating (attempt {})...",
+                    attempt + 1
+                );
+                account = reauth_or_fail(client, &account).await?;
+            }
             Err(e) => return Err(e).context("failed to get version metadata"),
-        };
+        }
+    }
+
+    let result = result.with_context(|| {
+        last_error.map_or_else(
+            || "failed to get version metadata after retries".to_string(),
+            |e| format!("failed to get version metadata after retries: {e}"),
+        )
+    })?;
 
     match format {
         OutputFormat::Text => {

--- a/crates/ipatool-core/Cargo.toml
+++ b/crates/ipatool-core/Cargo.toml
@@ -14,10 +14,12 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+time.workspace = true
 
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "cookies", "stream"] }
 plist = "1"
 zip = { version = "2", default-features = false, features = ["deflate"] }
+flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
 cookie_store = "0.21"
 reqwest_cookie_store = "0.8"

--- a/crates/ipatool-core/src/api/versions.rs
+++ b/crates/ipatool-core/src/api/versions.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use serde::Serialize;
+use time::format_description::well_known::Rfc3339;
 
 use crate::client::AppleClient;
 use crate::error::{ClientError, StoreError};
@@ -188,30 +189,13 @@ pub async fn get_version_metadata(
         crate::api::download::get_download_info(client, app_id, account, Some(external_version_id))
             .await?;
 
-    let bundle_short_version = item
-        .metadata
-        .get("bundleShortVersionString")
-        .and_then(|v| v.as_string())
-        .map(String::from);
+    let info = crate::ipa::partial_zip::read_remote_info_plist(client.http(), &item.url)
+        .await
+        .map_err(|e| {
+            ClientError::UnexpectedResponse(format!("failed to read version metadata: {e}"))
+        })?;
 
-    let bundle_version = item
-        .metadata
-        .get("bundleVersion")
-        .and_then(|v| v.as_string())
-        .map(String::from);
-
-    let release_date = item
-        .metadata
-        .get("releaseDate")
-        .and_then(|v| v.as_string())
-        .map(String::from);
-
-    Ok(VersionMetadata {
-        bundle_short_version,
-        bundle_version,
-        release_date,
-        extra: item.metadata,
-    })
+    version_metadata_from_info_plist(&info.plist, info.modified, item.metadata)
 }
 
 fn download_url(account: &Account, guid: &str) -> String {
@@ -220,6 +204,138 @@ fn download_url(account: &Account, guid: &str) -> String {
         None => "buy.itunes.apple.com".to_string(),
     };
     format!("https://{host}/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct?guid={guid}")
+}
+
+fn version_metadata_from_info_plist(
+    info: &plist::Dictionary,
+    modified: Option<zip::DateTime>,
+    extra: HashMap<String, plist::Value>,
+) -> Result<VersionMetadata, ClientError> {
+    let bundle_short_version = first_metadata_string(
+        info,
+        &["CFBundleShortVersionString", "bundleShortVersionString"],
+    );
+    let bundle_version = first_metadata_string(info, &["CFBundleVersion", "bundleVersion"]);
+    let release_date = release_date_from_info_plist(info, modified)?;
+
+    Ok(VersionMetadata {
+        bundle_short_version,
+        bundle_version,
+        release_date,
+        extra,
+    })
+}
+
+fn first_metadata_string(info: &plist::Dictionary, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| info.get(key).and_then(metadata_value_to_string))
+}
+
+fn metadata_value_to_string(value: &plist::Value) -> Option<String> {
+    let value = match value {
+        plist::Value::String(s) => s.trim().to_string(),
+        plist::Value::Integer(i) => i
+            .as_signed()
+            .map(|n| n.to_string())
+            .or_else(|| i.as_unsigned().map(|n| n.to_string()))?,
+        plist::Value::Real(n) => n.to_string(),
+        _ => return None,
+    };
+
+    if value.is_empty() { None } else { Some(value) }
+}
+
+fn release_date_from_info_plist(
+    info: &plist::Dictionary,
+    modified: Option<zip::DateTime>,
+) -> Result<Option<String>, ClientError> {
+    for key in ["releaseDate", "ReleaseDate"] {
+        if let Some(value) = info.get(key) {
+            return parse_release_date_value(value).map(Some);
+        }
+    }
+
+    Ok(modified.map(zip_datetime_to_rfc3339))
+}
+
+fn parse_release_date_value(value: &plist::Value) -> Result<String, ClientError> {
+    match value {
+        plist::Value::Date(date) => Ok(date.to_xml_format()),
+        plist::Value::String(s) => parse_release_date_string(s),
+        plist::Value::Integer(i) => {
+            let timestamp = i.as_signed().or_else(|| {
+                i.as_unsigned()
+                    .and_then(|n| (n <= i64::MAX as u64).then_some(n as i64))
+            });
+            let timestamp = timestamp.ok_or_else(|| {
+                ClientError::UnexpectedResponse("release date timestamp is too large".into())
+            })?;
+            unix_timestamp_to_rfc3339(timestamp)
+        }
+        plist::Value::Real(n) if n.is_finite() => unix_timestamp_to_rfc3339(*n as i64),
+        plist::Value::Real(_) => Err(ClientError::UnexpectedResponse(
+            "release date timestamp is not finite".into(),
+        )),
+        _ => Err(ClientError::UnexpectedResponse(format!(
+            "unsupported release date type: {value:?}"
+        ))),
+    }
+}
+
+fn parse_release_date_string(value: &str) -> Result<String, ClientError> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(ClientError::UnexpectedResponse(
+            "release date is empty".into(),
+        ));
+    }
+
+    if let Ok(parsed) = time::OffsetDateTime::parse(value, &Rfc3339) {
+        return format_datetime(parsed);
+    }
+
+    if is_date_only(value) {
+        return Ok(format!("{value}T00:00:00Z"));
+    }
+
+    Err(ClientError::UnexpectedResponse(format!(
+        "invalid release date: {value}"
+    )))
+}
+
+fn is_date_only(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() == 10
+        && bytes[4] == b'-'
+        && bytes[7] == b'-'
+        && bytes[..4].iter().all(u8::is_ascii_digit)
+        && bytes[5..7].iter().all(u8::is_ascii_digit)
+        && bytes[8..].iter().all(u8::is_ascii_digit)
+}
+
+fn unix_timestamp_to_rfc3339(timestamp: i64) -> Result<String, ClientError> {
+    let datetime = time::OffsetDateTime::from_unix_timestamp(timestamp)
+        .map_err(|e| ClientError::UnexpectedResponse(format!("invalid release date: {e}")))?;
+    format_datetime(datetime)
+}
+
+fn format_datetime(datetime: time::OffsetDateTime) -> Result<String, ClientError> {
+    datetime
+        .to_offset(time::UtcOffset::UTC)
+        .format(&Rfc3339)
+        .map_err(|e| ClientError::UnexpectedResponse(format!("format release date: {e}")))
+}
+
+fn zip_datetime_to_rfc3339(datetime: zip::DateTime) -> String {
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        datetime.year(),
+        datetime.month(),
+        datetime.day(),
+        datetime.hour(),
+        datetime.minute(),
+        datetime.second()
+    )
 }
 
 #[cfg(test)]
@@ -236,6 +352,75 @@ mod tests {
         let mut dict = HashMap::new();
         dict.insert("songList".into(), song_list);
         dict
+    }
+
+    fn stale_download_metadata() -> HashMap<String, plist::Value> {
+        HashMap::from([
+            (
+                "bundleShortVersionString".into(),
+                plist::Value::String("1.0".into()),
+            ),
+            ("bundleVersion".into(), plist::Value::String("100".into())),
+            (
+                "releaseDate".into(),
+                plist::Value::String("2010-04-01T20:36:57Z".into()),
+            ),
+        ])
+    }
+
+    #[test]
+    fn version_metadata_uses_info_plist_values_not_download_metadata() {
+        let mut info = plist::Dictionary::new();
+        info.insert(
+            "CFBundleShortVersionString".into(),
+            plist::Value::String("2.0".into()),
+        );
+        info.insert("CFBundleVersion".into(), plist::Value::String("200".into()));
+        info.insert(
+            "releaseDate".into(),
+            plist::Value::String("2024-04-02T12:00:00Z".into()),
+        );
+
+        let out = version_metadata_from_info_plist(&info, None, stale_download_metadata()).unwrap();
+
+        assert_eq!(out.bundle_short_version.as_deref(), Some("2.0"));
+        assert_eq!(out.bundle_version.as_deref(), Some("200"));
+        assert_eq!(out.release_date.as_deref(), Some("2024-04-02T12:00:00Z"));
+        assert_eq!(
+            out.extra.get("releaseDate").and_then(|v| v.as_string()),
+            Some("2010-04-01T20:36:57Z")
+        );
+    }
+
+    #[test]
+    fn version_metadata_falls_back_to_info_plist_zip_time() {
+        let mut info = plist::Dictionary::new();
+        info.insert(
+            "CFBundleShortVersionString".into(),
+            plist::Value::String("2.0".into()),
+        );
+        let modified = zip::DateTime::from_date_and_time(2024, 3, 19, 12, 0, 0).unwrap();
+
+        let out =
+            version_metadata_from_info_plist(&info, Some(modified), stale_download_metadata())
+                .unwrap();
+
+        assert_eq!(out.release_date.as_deref(), Some("2024-03-19T12:00:00Z"));
+    }
+
+    #[test]
+    fn invalid_info_plist_release_date_is_an_error() {
+        let mut info = plist::Dictionary::new();
+        info.insert(
+            "releaseDate".into(),
+            plist::Value::String("not-a-date".into()),
+        );
+
+        let err = version_metadata_from_info_plist(&info, None, HashMap::new()).unwrap_err();
+
+        assert!(
+            matches!(err, ClientError::UnexpectedResponse(msg) if msg == "invalid release date: not-a-date")
+        );
     }
 
     #[test]

--- a/crates/ipatool-core/src/ipa/partial_zip.rs
+++ b/crates/ipatool-core/src/ipa/partial_zip.rs
@@ -1,18 +1,70 @@
-use std::io::{Read, Seek, SeekFrom};
+use std::io::Read;
+
+use flate2::read::DeflateDecoder;
 
 use crate::error::ClientError;
 
-pub struct HttpReader {
+const LOCAL_FILE_HEADER_SIGNATURE: u32 = 0x0403_4b50;
+const CENTRAL_DIRECTORY_HEADER_SIGNATURE: u32 = 0x0201_4b50;
+const END_OF_CENTRAL_DIRECTORY_SIGNATURE: u32 = 0x0605_4b50;
+const ZIP64_END_OF_CENTRAL_DIRECTORY_SIGNATURE: u32 = 0x0606_4b50;
+const ZIP64_END_OF_CENTRAL_DIRECTORY_LOCATOR_SIGNATURE: u32 = 0x0706_4b50;
+
+const EOCD_MIN_SIZE: usize = 22;
+const ZIP64_EOCD_LOCATOR_SIZE: u64 = 20;
+const ZIP64_EOCD_MIN_SIZE: u64 = 56;
+const MAX_ZIP_COMMENT_SIZE: u64 = u16::MAX as u64;
+const ZIP32_MAX: u64 = u32::MAX as u64;
+const ZIP16_MAX: u64 = u16::MAX as u64;
+const ZIP64_EXTRA_FIELD_ID: u16 = 0x0001;
+
+pub struct RemoteInfoPlist {
+    pub plist: plist::Dictionary,
+    pub modified: Option<zip::DateTime>,
+}
+
+struct RemoteZip {
     client: reqwest::Client,
     url: String,
     size: u64,
-    pos: u64,
-    runtime: tokio::runtime::Handle,
 }
 
-impl HttpReader {
-    pub async fn new(client: &reqwest::Client, url: &str) -> Result<Self, ClientError> {
-        let resp = client.get(url).header("Range", "bytes=0-0").send().await?;
+struct EndOfCentralDirectory {
+    offset: u64,
+    entries: u64,
+    central_directory_size: u64,
+    central_directory_offset: u64,
+}
+
+struct CentralDirectory {
+    size: u64,
+    offset: u64,
+}
+
+struct CentralDirectoryEntry {
+    compression_method: u16,
+    flags: u16,
+    compressed_size: u64,
+    uncompressed_size: u64,
+    local_header_offset: u64,
+    modified: Option<zip::DateTime>,
+}
+
+impl RemoteZip {
+    async fn new(client: &reqwest::Client, url: &str) -> Result<Self, ClientError> {
+        let resp = client
+            .get(url)
+            .header("Accept-Encoding", "identity")
+            .header("Range", "bytes=0-0")
+            .send()
+            .await?;
+
+        if resp.status() != reqwest::StatusCode::PARTIAL_CONTENT {
+            return Err(zip_error(format!(
+                "expected partial content response, got status {}",
+                resp.status()
+            )));
+        }
 
         let size = resp
             .headers()
@@ -20,102 +72,493 @@ impl HttpReader {
             .and_then(|v| v.to_str().ok())
             .and_then(|s| s.rsplit('/').next())
             .and_then(|s| s.parse::<u64>().ok())
-            .ok_or_else(|| {
-                ClientError::UnexpectedResponse("missing Content-Range for size".into())
-            })?;
+            .ok_or_else(|| zip_error("missing Content-Range for size"))?;
 
         Ok(Self {
             client: client.clone(),
             url: url.to_string(),
             size,
-            pos: 0,
-            runtime: tokio::runtime::Handle::current(),
         })
     }
 
-    pub fn size(&self) -> u64 {
-        self.size
-    }
-}
-
-impl Read for HttpReader {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        if self.pos >= self.size {
-            return Ok(0);
+    async fn read_range(&self, start: u64, len: u64) -> Result<Vec<u8>, ClientError> {
+        if len == 0 {
+            return Ok(Vec::new());
         }
 
-        let end = std::cmp::min(self.pos + buf.len() as u64 - 1, self.size - 1);
-        let range = format!("bytes={}-{}", self.pos, end);
+        if start >= self.size {
+            return Err(zip_error("range starts past end of file"));
+        }
+
+        let end = start
+            .checked_add(len - 1)
+            .ok_or_else(|| zip_error("range end overflow"))?
+            .min(self.size - 1);
+        let range = format!("bytes={start}-{end}");
 
         let resp = self
-            .runtime
-            .block_on(async {
-                self.client
-                    .get(&self.url)
-                    .header("Range", &range)
-                    .send()
-                    .await?
-                    .bytes()
-                    .await
-            })
-            .map_err(std::io::Error::other)?;
+            .client
+            .get(&self.url)
+            .header("Accept-Encoding", "identity")
+            .header("Range", range)
+            .send()
+            .await?;
 
-        let n = resp.len();
-        buf[..n].copy_from_slice(&resp);
-        self.pos += n as u64;
-        Ok(n)
+        if resp.status() != reqwest::StatusCode::PARTIAL_CONTENT {
+            return Err(zip_error(format!(
+                "expected partial content response, got status {}",
+                resp.status()
+            )));
+        }
+
+        let bytes = resp.bytes().await?;
+        let expected = as_usize(end - start + 1, "range length")?;
+        if bytes.len() != expected {
+            return Err(zip_error(format!(
+                "short range response: expected {expected} bytes, got {}",
+                bytes.len()
+            )));
+        }
+
+        Ok(bytes.to_vec())
+    }
+
+    async fn read_central_directory(&self) -> Result<Vec<u8>, ClientError> {
+        let tail_len = self.size.min(MAX_ZIP_COMMENT_SIZE + EOCD_MIN_SIZE as u64);
+        let tail_start = self.size - tail_len;
+        let tail = self.read_range(tail_start, tail_len).await?;
+        let eocd = find_eocd_in_tail(&tail, tail_start)?;
+        let directory = if eocd.needs_zip64() {
+            self.read_zip64_central_directory(&eocd).await?
+        } else {
+            CentralDirectory {
+                size: eocd.central_directory_size,
+                offset: eocd.central_directory_offset,
+            }
+        };
+
+        self.read_range(directory.offset, directory.size).await
+    }
+
+    async fn read_zip64_central_directory(
+        &self,
+        eocd: &EndOfCentralDirectory,
+    ) -> Result<CentralDirectory, ClientError> {
+        if eocd.offset < ZIP64_EOCD_LOCATOR_SIZE {
+            return Err(zip_error("missing ZIP64 end of central directory locator"));
+        }
+
+        let locator = self
+            .read_range(
+                eocd.offset - ZIP64_EOCD_LOCATOR_SIZE,
+                ZIP64_EOCD_LOCATOR_SIZE,
+            )
+            .await?;
+        let signature = read_u32_le(&locator, 0, "ZIP64 locator signature")?;
+        if signature != ZIP64_END_OF_CENTRAL_DIRECTORY_LOCATOR_SIGNATURE {
+            return Err(zip_error("invalid ZIP64 end of central directory locator"));
+        }
+
+        let disk_number = read_u32_le(&locator, 4, "ZIP64 locator disk number")?;
+        let eocd64_offset = read_u64_le(&locator, 8, "ZIP64 EOCD offset")?;
+        let number_of_disks = read_u32_le(&locator, 16, "ZIP64 locator disk count")?;
+        if disk_number != 0 || number_of_disks > 1 {
+            return Err(zip_error("multi-disk ZIP archives are not supported"));
+        }
+
+        let record = self.read_range(eocd64_offset, ZIP64_EOCD_MIN_SIZE).await?;
+        let signature = read_u32_le(&record, 0, "ZIP64 EOCD signature")?;
+        if signature != ZIP64_END_OF_CENTRAL_DIRECTORY_SIGNATURE {
+            return Err(zip_error("invalid ZIP64 end of central directory"));
+        }
+
+        let record_size = read_u64_le(&record, 4, "ZIP64 EOCD size")?;
+        if record_size < 44 {
+            return Err(zip_error("invalid ZIP64 end of central directory size"));
+        }
+
+        let disk_number = read_u32_le(&record, 16, "ZIP64 EOCD disk number")?;
+        let central_directory_disk = read_u32_le(&record, 20, "ZIP64 EOCD central directory disk")?;
+        if disk_number != 0 || central_directory_disk != 0 {
+            return Err(zip_error("multi-disk ZIP archives are not supported"));
+        }
+
+        Ok(CentralDirectory {
+            size: read_u64_le(&record, 40, "ZIP64 EOCD central directory size")?,
+            offset: read_u64_le(&record, 48, "ZIP64 EOCD central directory offset")?,
+        })
     }
 }
 
-impl Seek for HttpReader {
-    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
-        self.pos = match pos {
-            SeekFrom::Start(n) => n,
-            SeekFrom::End(n) => (self.size as i64 + n) as u64,
-            SeekFrom::Current(n) => (self.pos as i64 + n) as u64,
-        };
-        Ok(self.pos)
+impl EndOfCentralDirectory {
+    fn needs_zip64(&self) -> bool {
+        self.entries == ZIP16_MAX
+            || self.central_directory_size == ZIP32_MAX
+            || self.central_directory_offset == ZIP32_MAX
     }
 }
 
 pub async fn read_remote_info_plist(
     client: &reqwest::Client,
     url: &str,
-) -> Result<plist::Dictionary, ClientError> {
-    let reader = HttpReader::new(client, url).await?;
-    let size = reader.size();
+) -> Result<RemoteInfoPlist, ClientError> {
+    let remote = RemoteZip::new(client, url).await?;
+    let central_directory = remote.read_central_directory().await?;
+    let entry = find_info_plist_entry(&central_directory)?;
 
-    let archive = zip::ZipArchive::new(reader)
-        .map_err(|e| ClientError::UnexpectedResponse(format!("zip: {e}")))?;
+    let local_header = remote.read_range(entry.local_header_offset, 30).await?;
+    let data_offset = local_file_data_offset(&local_header, entry.local_header_offset)?;
+    let compressed = remote
+        .read_range(data_offset, entry.compressed_size)
+        .await?;
+    let plist_bytes = decompress_entry(&entry, &compressed)?;
+    let plist = plist::from_bytes(&plist_bytes).map_err(ClientError::PlistDe)?;
 
-    let info_plist_name = archive
-        .file_names()
-        .find(|name| {
-            name.starts_with("Payload/")
-                && name.ends_with(".app/Info.plist")
-                && !name.contains("Watch/")
-                && name.matches('/').count() == 2
-        })
-        .map(String::from)
-        .ok_or_else(|| ClientError::UnexpectedResponse("no Info.plist found".into()))?;
-
-    let mut archive = zip::ZipArchive::new(HttpReader {
-        client: client.clone(),
-        url: url.to_string(),
-        size,
-        pos: 0,
-        runtime: tokio::runtime::Handle::current(),
+    Ok(RemoteInfoPlist {
+        plist,
+        modified: entry.modified,
     })
-    .map_err(|e| ClientError::UnexpectedResponse(format!("zip reopen: {e}")))?;
+}
 
-    let mut entry = archive
-        .by_name(&info_plist_name)
-        .map_err(|e| ClientError::UnexpectedResponse(format!("zip entry: {e}")))?;
+fn find_eocd_in_tail(tail: &[u8], tail_start: u64) -> Result<EndOfCentralDirectory, ClientError> {
+    if tail.len() < EOCD_MIN_SIZE {
+        return Err(zip_error(
+            "file is too small to contain an end of central directory",
+        ));
+    }
 
-    let mut buf = Vec::new();
-    entry
-        .read_to_end(&mut buf)
-        .map_err(|e| ClientError::UnexpectedResponse(format!("zip read: {e}")))?;
+    for pos in (0..=tail.len() - EOCD_MIN_SIZE).rev() {
+        let signature = read_u32_le(tail, pos, "EOCD signature")?;
+        if signature != END_OF_CENTRAL_DIRECTORY_SIGNATURE {
+            continue;
+        }
 
-    plist::from_bytes(&buf).map_err(ClientError::PlistDe)
+        let comment_len = read_u16_le(tail, pos + 20, "EOCD comment length")? as usize;
+        if pos + EOCD_MIN_SIZE + comment_len != tail.len() {
+            continue;
+        }
+
+        let disk_number = read_u16_le(tail, pos + 4, "EOCD disk number")?;
+        let central_directory_disk = read_u16_le(tail, pos + 6, "EOCD central directory disk")?;
+        if disk_number != 0 || central_directory_disk != 0 {
+            return Err(zip_error("multi-disk ZIP archives are not supported"));
+        }
+
+        return Ok(EndOfCentralDirectory {
+            offset: tail_start + pos as u64,
+            entries: read_u16_le(tail, pos + 10, "EOCD total entries")? as u64,
+            central_directory_size: read_u32_le(tail, pos + 12, "EOCD central directory size")?
+                as u64,
+            central_directory_offset: read_u32_le(tail, pos + 16, "EOCD central directory offset")?
+                as u64,
+        });
+    }
+
+    Err(zip_error("could not find end of central directory"))
+}
+
+fn find_info_plist_entry(central_directory: &[u8]) -> Result<CentralDirectoryEntry, ClientError> {
+    let mut pos = 0;
+    while pos < central_directory.len() {
+        let entry = parse_central_directory_entry(central_directory, pos)?;
+        if is_target_info_plist(&entry.0) {
+            return Ok(entry.1);
+        }
+        pos = entry.2;
+    }
+
+    Err(zip_error("no Info.plist found"))
+}
+
+fn parse_central_directory_entry(
+    central_directory: &[u8],
+    pos: usize,
+) -> Result<(String, CentralDirectoryEntry, usize), ClientError> {
+    let signature = read_u32_le(central_directory, pos, "central directory signature")?;
+    if signature != CENTRAL_DIRECTORY_HEADER_SIGNATURE {
+        return Err(zip_error("invalid central directory header"));
+    }
+
+    let flags = read_u16_le(central_directory, pos + 8, "central directory flags")?;
+    let compression_method = read_u16_le(
+        central_directory,
+        pos + 10,
+        "central directory compression method",
+    )?;
+    let last_mod_time = read_u16_le(
+        central_directory,
+        pos + 12,
+        "central directory modified time",
+    )?;
+    let last_mod_date = read_u16_le(
+        central_directory,
+        pos + 14,
+        "central directory modified date",
+    )?;
+    let file_name_len =
+        read_u16_le(central_directory, pos + 28, "central directory name length")? as usize;
+    let extra_field_len = read_u16_le(
+        central_directory,
+        pos + 30,
+        "central directory extra field length",
+    )? as usize;
+    let comment_len = read_u16_le(
+        central_directory,
+        pos + 32,
+        "central directory comment length",
+    )? as usize;
+
+    let file_name_start = pos + 46;
+    let extra_field_start = file_name_start + file_name_len;
+    let comment_start = extra_field_start + extra_field_len;
+    let next = comment_start + comment_len;
+
+    let file_name_raw = checked_slice(
+        central_directory,
+        file_name_start,
+        file_name_len,
+        "central directory file name",
+    )?;
+    let extra_field = checked_slice(
+        central_directory,
+        extra_field_start,
+        extra_field_len,
+        "central directory extra field",
+    )?;
+    checked_slice(
+        central_directory,
+        comment_start,
+        comment_len,
+        "central directory comment",
+    )?;
+
+    let file_name = String::from_utf8_lossy(file_name_raw).into_owned();
+    let mut entry = CentralDirectoryEntry {
+        compression_method,
+        flags,
+        compressed_size: read_u32_le(
+            central_directory,
+            pos + 20,
+            "central directory compressed size",
+        )? as u64,
+        uncompressed_size: read_u32_le(
+            central_directory,
+            pos + 24,
+            "central directory uncompressed size",
+        )? as u64,
+        local_header_offset: read_u32_le(
+            central_directory,
+            pos + 42,
+            "central directory local header offset",
+        )? as u64,
+        modified: zip::DateTime::try_from_msdos(last_mod_date, last_mod_time).ok(),
+    };
+
+    apply_zip64_extra_field(extra_field, &mut entry)?;
+
+    Ok((file_name, entry, next))
+}
+
+fn apply_zip64_extra_field(
+    extra_field: &[u8],
+    entry: &mut CentralDirectoryEntry,
+) -> Result<(), ClientError> {
+    let needs_uncompressed_size = entry.uncompressed_size == ZIP32_MAX;
+    let needs_compressed_size = entry.compressed_size == ZIP32_MAX;
+    let needs_local_header_offset = entry.local_header_offset == ZIP32_MAX;
+
+    let mut pos = 0;
+    while pos + 4 <= extra_field.len() {
+        let header_id = read_u16_le(extra_field, pos, "extra field header id")?;
+        let data_size = read_u16_le(extra_field, pos + 2, "extra field data size")? as usize;
+        pos += 4;
+
+        let data = checked_slice(extra_field, pos, data_size, "extra field data")?;
+        if header_id == ZIP64_EXTRA_FIELD_ID {
+            let mut data_pos = 0;
+            if needs_uncompressed_size {
+                entry.uncompressed_size = read_u64_le(data, data_pos, "ZIP64 uncompressed size")?;
+                data_pos += 8;
+            }
+            if needs_compressed_size {
+                entry.compressed_size = read_u64_le(data, data_pos, "ZIP64 compressed size")?;
+                data_pos += 8;
+            }
+            if needs_local_header_offset {
+                entry.local_header_offset =
+                    read_u64_le(data, data_pos, "ZIP64 local header offset")?;
+            }
+            break;
+        }
+
+        pos += data_size;
+    }
+
+    if entry.uncompressed_size == ZIP32_MAX
+        || entry.compressed_size == ZIP32_MAX
+        || entry.local_header_offset == ZIP32_MAX
+    {
+        return Err(zip_error("missing ZIP64 extra field values"));
+    }
+
+    Ok(())
+}
+
+fn local_file_data_offset(
+    local_header: &[u8],
+    local_header_offset: u64,
+) -> Result<u64, ClientError> {
+    let signature = read_u32_le(local_header, 0, "local file header signature")?;
+    if signature != LOCAL_FILE_HEADER_SIGNATURE {
+        return Err(zip_error("invalid local file header"));
+    }
+
+    let file_name_len = read_u16_le(local_header, 26, "local file name length")? as u64;
+    let extra_field_len = read_u16_le(local_header, 28, "local file extra field length")? as u64;
+    local_header_offset
+        .checked_add(30)
+        .and_then(|offset| offset.checked_add(file_name_len))
+        .and_then(|offset| offset.checked_add(extra_field_len))
+        .ok_or_else(|| zip_error("local file data offset overflow"))
+}
+
+fn decompress_entry(
+    entry: &CentralDirectoryEntry,
+    compressed: &[u8],
+) -> Result<Vec<u8>, ClientError> {
+    if entry.flags & 1 == 1 {
+        return Err(zip_error("encrypted Info.plist entries are not supported"));
+    }
+
+    let mut out = Vec::with_capacity(as_usize(
+        entry.uncompressed_size.min(1024 * 1024),
+        "uncompressed size",
+    )?);
+    match entry.compression_method {
+        0 => out.extend_from_slice(compressed),
+        8 => {
+            let mut decoder = DeflateDecoder::new(compressed);
+            decoder
+                .read_to_end(&mut out)
+                .map_err(|e| zip_error(format!("deflate: {e}")))?;
+        }
+        method => {
+            return Err(zip_error(format!(
+                "unsupported Info.plist compression method {method}"
+            )));
+        }
+    }
+
+    if out.len() as u64 != entry.uncompressed_size {
+        return Err(zip_error(format!(
+            "Info.plist size mismatch: expected {}, got {}",
+            entry.uncompressed_size,
+            out.len()
+        )));
+    }
+
+    Ok(out)
+}
+
+fn is_target_info_plist(name: &str) -> bool {
+    name.starts_with("Payload/")
+        && name.ends_with(".app/Info.plist")
+        && !name.contains("Watch/")
+        && name.matches('/').count() == 2
+}
+
+fn read_u16_le(buf: &[u8], offset: usize, field: &str) -> Result<u16, ClientError> {
+    Ok(u16::from_le_bytes(read_array(buf, offset, field)?))
+}
+
+fn read_u32_le(buf: &[u8], offset: usize, field: &str) -> Result<u32, ClientError> {
+    Ok(u32::from_le_bytes(read_array(buf, offset, field)?))
+}
+
+fn read_u64_le(buf: &[u8], offset: usize, field: &str) -> Result<u64, ClientError> {
+    Ok(u64::from_le_bytes(read_array(buf, offset, field)?))
+}
+
+fn read_array<const N: usize>(
+    buf: &[u8],
+    offset: usize,
+    field: &str,
+) -> Result<[u8; N], ClientError> {
+    let end = offset
+        .checked_add(N)
+        .ok_or_else(|| zip_error(format!("{field} offset overflow")))?;
+    let bytes = buf
+        .get(offset..end)
+        .ok_or_else(|| zip_error(format!("truncated {field}")))?;
+    Ok(bytes.try_into().expect("slice length was checked"))
+}
+
+fn checked_slice<'a>(
+    buf: &'a [u8],
+    offset: usize,
+    len: usize,
+    field: &str,
+) -> Result<&'a [u8], ClientError> {
+    let end = offset
+        .checked_add(len)
+        .ok_or_else(|| zip_error(format!("{field} offset overflow")))?;
+    buf.get(offset..end)
+        .ok_or_else(|| zip_error(format!("truncated {field}")))
+}
+
+fn as_usize(value: u64, field: &str) -> Result<usize, ClientError> {
+    usize::try_from(value).map_err(|_| zip_error(format!("{field} is too large")))
+}
+
+fn zip_error(message: impl Into<String>) -> ClientError {
+    ClientError::UnexpectedResponse(format!("zip: {}", message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, Write};
+
+    use zip::write::SimpleFileOptions;
+
+    use super::*;
+
+    #[test]
+    fn reads_deflated_payload_info_plist_from_zip_metadata() {
+        let info_plist =
+            br#"<?xml version="1.0"?><plist version="1.0"><dict><key>CFBundleVersion</key><string>1</string></dict></plist>"#;
+        let mut zip_data = Cursor::new(Vec::new());
+        {
+            let mut writer = zip::ZipWriter::new(&mut zip_data);
+            writer
+                .start_file(
+                    "Payload/Test.app/Info.plist",
+                    SimpleFileOptions::default()
+                        .compression_method(zip::CompressionMethod::Deflated),
+                )
+                .unwrap();
+            writer.write_all(info_plist).unwrap();
+            writer.finish().unwrap();
+        }
+
+        let zip_data = zip_data.into_inner();
+        let eocd = find_eocd_in_tail(&zip_data, 0).unwrap();
+        let central_directory = &zip_data[eocd.central_directory_offset as usize
+            ..(eocd.central_directory_offset + eocd.central_directory_size) as usize];
+        let entry = find_info_plist_entry(central_directory).unwrap();
+        let local_header =
+            &zip_data[entry.local_header_offset as usize..entry.local_header_offset as usize + 30];
+        let data_offset = local_file_data_offset(local_header, entry.local_header_offset).unwrap();
+        let compressed =
+            &zip_data[data_offset as usize..(data_offset + entry.compressed_size) as usize];
+
+        assert_eq!(decompress_entry(&entry, compressed).unwrap(), info_plist);
+    }
+
+    #[test]
+    fn ignores_nested_watch_info_plist() {
+        assert!(!is_target_info_plist(
+            "Payload/Test.app/Watch/Test Watch.app/Info.plist"
+        ));
+        assert!(is_target_info_plist("Payload/Test.app/Info.plist"));
+    }
 }


### PR DESCRIPTION
## Summary
- Read version metadata from the selected IPA's main Info.plist instead of stale App Store download metadata.
- Add targeted remote ZIP range reading for Info.plist.
- Re-authenticate version commands when password tokens expire.

## Validation
- cargo fmt --check
- cargo check --workspace
- cargo test --workspace
- cargo clippy --all-targets -- -D warnings
- git diff --check
- cargo run --quiet -- version meta -i 361309726 --version-id 882423354
- cargo run --quiet -- version list -i 361309726