### PR TITLE
feat: harden credential handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stop persisting the raw Apple ID password in stored credentials and redact it from account JSON output.
 - Limit verbose logging to `ipatool` crates and remove App Store response body previews from debug logs.
 - Create the `~/.ipatool` data directory and cookie file with private permissions on Unix platforms.
+- Validate IPA download HTTP responses, fail stalled downloads, and add ranged parallel CLI downloads with `--connections`.
 
 ## [0.1.3] - 2026-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Stop persisting the raw Apple ID password in stored credentials and redact it from account JSON output.
+- Limit verbose logging to `ipatool` crates and remove App Store response body previews from debug logs.
+- Create the `~/.ipatool` data directory and cookie file with private permissions on Unix platforms.
+
 ## [0.1.3] - 2026-06-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ Use `-o` to choose a different output path.
 # Download with auto-purchase
 ipatool download -b com.tencent.xin --purchase
 
+# Use fewer or more ranged connections if a CDN path is slow or flaky
+ipatool download -b com.tencent.xin --purchase --connections 4
+
 # Specify output path
 ipatool download -b com.tencent.xin --purchase -o ~/Downloads/wechat.ipa
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This rewrite adds a keyboard-driven terminal UI, structured Rust models, clearer
 - Search-to-download workflow: browse App Store results, inspect app details, purchase free licenses, and queue downloads from one screen.
 - Download dashboard: track progress, failures, cancellation, and completed items in the Downloads tab.
 - Account management: log in, handle 2FA, view the active account, and revoke stored credentials.
-- Resilient sessions: refresh expired tokens during purchase and download flows when stored credentials are available.
+- Resilient sessions: refresh expired tokens during long-running interactive sessions when the password is still in memory.
 - Robust downloads: stream IPA files with progress display and HTTP Range resume support in CLI mode.
 - Patch-ready IPAs: inject purchase metadata and SINF authorization data into the downloaded archive.
 - Text or JSON output for scripts and automation.
@@ -93,11 +93,11 @@ The UI is built with [ratatui](https://ratatui.rs/) and [crossterm](https://gith
 Log in with your Apple ID. Two-factor authentication is supported.
 
 ```bash
-# Interactive login (prompts for a 2FA code if Apple requires one)
-ipatool auth login --email your@apple.id --password 'password'
+# Interactive login (prompts for the password and 2FA code if Apple requires one)
+ipatool auth login --email your@apple.id
 
-# With 2FA code
-ipatool auth login --email your@apple.id --password 'password' --auth-code 123456
+# Non-interactive mode still supports --password and --auth-code for controlled automation,
+# but those values can be visible in shell history and process lists.
 
 # Show current account
 ipatool auth info
@@ -216,7 +216,7 @@ ipatool-rs/
 
 ## How It Works
 
-1. **Auth** - Posts credentials to Apple's native auth endpoint using the legacy MZFinance protocol. Handles 2FA, redirects, retry logic, keychain storage, and cookies.
+1. **Auth** - Posts credentials to Apple's native auth endpoint using the legacy MZFinance protocol. Handles 2FA, redirects, retry logic, keychain storage for account tokens, and cookies. The raw Apple ID password is not persisted.
 
 2. **Search/Lookup** - Queries the public iTunes Search API for app metadata and storefront-specific results.
 

--- a/crates/ipatool-cli/src/commands/download.rs
+++ b/crates/ipatool-cli/src/commands/download.rs
@@ -22,6 +22,7 @@ pub async fn download(
     output: Option<PathBuf>,
     do_purchase: bool,
     platform: Platform,
+    connections: usize,
     account: &Account,
 ) -> Result<()> {
     let mut account = account.clone();
@@ -100,7 +101,7 @@ pub async fn download(
     let tmp_path = dest.with_extension("ipa.tmp");
 
     eprintln!("Downloading to {}", tmp_path.display());
-    api::download::download_file(client, &item.url, &tmp_path, true)
+    api::download::download_file_with_connections(client, &item.url, &tmp_path, true, connections)
         .await
         .context("download failed")?;
 

--- a/crates/ipatool-cli/src/main.rs
+++ b/crates/ipatool-cli/src/main.rs
@@ -109,7 +109,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     let filter = if cli.verbose {
-        EnvFilter::new("debug")
+        EnvFilter::new("warn,ipatool=debug,ipatool_core=debug")
     } else {
         EnvFilter::from_default_env()
     };
@@ -126,7 +126,7 @@ async fn main() -> Result<()> {
     let guid_str = guid::generate_guid().context("failed to generate GUID")?;
 
     let data_dir = data_dir();
-    std::fs::create_dir_all(&data_dir).ok();
+    prepare_data_dir(&data_dir).ok();
     let cookie_path = data_dir.join("cookies.json");
 
     let mut client = ipatool_core::client::AppleClient::new(guid_str, Some(&cookie_path))
@@ -231,6 +231,19 @@ async fn main() -> Result<()> {
 pub(crate) fn data_dir() -> std::path::PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
     std::path::PathBuf::from(home).join(".ipatool")
+}
+
+pub(crate) fn prepare_data_dir(path: &std::path::Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(path)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
+    }
+
+    Ok(())
 }
 
 fn load_account() -> Result<ipatool_core::model::Account> {

--- a/crates/ipatool-cli/src/main.rs
+++ b/crates/ipatool-cli/src/main.rs
@@ -65,6 +65,8 @@ enum Commands {
         purchase: bool,
         #[arg(long, default_value = "iphone")]
         platform: Platform,
+        #[arg(long, default_value = "4")]
+        connections: usize,
     },
     Version {
         #[command(subcommand)]
@@ -172,6 +174,7 @@ async fn main() -> Result<()> {
             output,
             purchase,
             platform,
+            connections,
         } => {
             let account = load_account()?;
             client.set_account(account.clone());
@@ -183,6 +186,7 @@ async fn main() -> Result<()> {
                 output,
                 purchase,
                 platform,
+                connections,
                 &account,
             )
             .await?

--- a/crates/ipatool-cli/src/output.rs
+++ b/crates/ipatool-cli/src/output.rs
@@ -36,6 +36,16 @@ pub fn print_apps(apps: &[ipatool_core::model::App], format: OutputFormat) {
     }
 }
 
+#[derive(Serialize)]
+struct AccountOutput<'a> {
+    name: &'a str,
+    email: &'a str,
+    directory_services_id: &'a str,
+    store_front: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pod: Option<&'a str>,
+}
+
 pub fn print_account(account: &ipatool_core::model::Account, format: OutputFormat) {
     match format {
         OutputFormat::Text => {
@@ -47,6 +57,12 @@ pub fn print_account(account: &ipatool_core::model::Account, format: OutputForma
                 println!("Pod:      {pod}");
             }
         }
-        OutputFormat::Json => print_json(account),
+        OutputFormat::Json => print_json(&AccountOutput {
+            name: &account.name,
+            email: &account.email,
+            directory_services_id: &account.directory_services_id,
+            store_front: &account.store_front,
+            pod: account.pod.as_deref(),
+        }),
     }
 }

--- a/crates/ipatool-cli/src/tui/mod.rs
+++ b/crates/ipatool-cli/src/tui/mod.rs
@@ -795,7 +795,35 @@ async fn stream_download(
         c.http().clone()
     };
 
-    let resp = http.get(url).send().await.map_err(|e| e.to_string())?;
+    let resp = http
+        .get(url)
+        .header("Accept-Encoding", "identity")
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("<missing>")
+        .to_string();
+    let content_length = resp
+        .content_length()
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "<missing>".into());
+    let looks_like_error = {
+        let content_type = content_type.to_ascii_lowercase();
+        content_type.starts_with("text/")
+            || content_type.contains("html")
+            || content_type.contains("json")
+    };
+
+    if !status.is_success() || looks_like_error {
+        return Err(format!(
+            "download: HTTP {status}, content-type {content_type}, content-length {content_length}"
+        ));
+    }
     let total_size = resp.content_length().unwrap_or(0);
 
     tx.send(Action::DownloadProgress {
@@ -817,9 +845,9 @@ async fn stream_download(
 
     loop {
         tokio::select! {
-            chunk = stream.next() => {
+            chunk = tokio::time::timeout(std::time::Duration::from_secs(60), stream.next()) => {
                 match chunk {
-                    Some(Ok(bytes)) => {
+                    Ok(Some(Ok(bytes))) => {
                         file.write_all(&bytes).await.map_err(|_| "write error".to_string())?;
                         downloaded += bytes.len() as u64;
                         let now = tokio::time::Instant::now();
@@ -834,8 +862,9 @@ async fn stream_download(
                             .ok();
                         }
                     }
-                    Some(Err(e)) => return Err(e.to_string()),
-                    None => break,
+                    Ok(Some(Err(e))) => return Err(e.to_string()),
+                    Ok(None) => break,
+                    Err(_) => return Err("download stalled for 60 seconds".to_string()),
                 }
             }
             _ = cancel_token.cancelled() => {

--- a/crates/ipatool-cli/src/tui/mod.rs
+++ b/crates/ipatool-cli/src/tui/mod.rs
@@ -30,7 +30,7 @@ use tokio_util::sync::CancellationToken;
 use futures_util::StreamExt;
 use tokio::io::AsyncWriteExt;
 
-use crate::data_dir;
+use crate::{data_dir, prepare_data_dir};
 
 use self::action::Action;
 use self::app::{ActiveTab, App_, DownloadStage, InputMode};
@@ -39,7 +39,7 @@ use self::event::{Event, EventHandler};
 pub async fn run() -> Result<()> {
     let guid_str = ipatool_core::guid::generate_guid().context("failed to generate GUID")?;
     let data_dir = data_dir();
-    std::fs::create_dir_all(&data_dir).ok();
+    prepare_data_dir(&data_dir).ok();
     let cookie_path = data_dir.join("cookies.json");
 
     let client =

--- a/crates/ipatool-core/src/api/auth.rs
+++ b/crates/ipatool-core/src/api/auth.rs
@@ -79,11 +79,7 @@ pub async fn login(
 
         let resp_body = resp.bytes().await?;
 
-        tracing::debug!(
-            len = resp_body.len(),
-            preview = %String::from_utf8_lossy(&resp_body[..resp_body.len().min(500)]),
-            "auth response body"
-        );
+        tracing::debug!(len = resp_body.len(), "auth response body received");
 
         if resp_body.is_empty() {
             return Err(ClientError::UnexpectedResponse(format!(

--- a/crates/ipatool-core/src/api/download.rs
+++ b/crates/ipatool-core/src/api/download.rs
@@ -120,11 +120,7 @@ async fn try_get_download_info(
     tracing::debug!(%status, "download response status");
 
     let resp_body = resp.bytes().await?;
-    tracing::debug!(
-        len = resp_body.len(),
-        preview = %String::from_utf8_lossy(&resp_body[..resp_body.len().min(500)]),
-        "download response body"
-    );
+    tracing::debug!(len = resp_body.len(), "download response body received");
     let dict: HashMap<String, plist::Value> =
         crate::client::plist_xml::parse_plist_response(&resp_body)?;
 

--- a/crates/ipatool-core/src/api/download.rs
+++ b/crates/ipatool-core/src/api/download.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 use std::path::Path;
+use std::path::PathBuf;
+use std::time::Duration;
 
 use futures_util::StreamExt;
+use futures_util::stream::FuturesUnordered;
 use indicatif::{ProgressBar, ProgressStyle};
 use serde::Deserialize;
 use tokio::io::AsyncWriteExt;
@@ -42,6 +45,7 @@ mod serde_bytes {
 }
 
 const MAX_DOWNLOAD_ATTEMPTS: u32 = 3;
+const DOWNLOAD_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
 pub async fn get_download_info(
     client: &AppleClient,
@@ -175,6 +179,37 @@ pub async fn download_file(
     dest: &Path,
     show_progress: bool,
 ) -> Result<(), ClientError> {
+    download_file_with_connections(client, url, dest, show_progress, 1).await
+}
+
+pub async fn download_file_with_connections(
+    client: &AppleClient,
+    url: &str,
+    dest: &Path,
+    show_progress: bool,
+    connections: usize,
+) -> Result<(), ClientError> {
+    if connections <= 1 {
+        return download_file_sequential(client, url, dest, show_progress).await;
+    }
+
+    match fetch_download_size(client, url).await {
+        Ok(size) => {
+            download_file_parallel(client, url, dest, show_progress, connections, size).await
+        }
+        Err(err) => {
+            tracing::warn!(%err, "parallel download unavailable, falling back to sequential");
+            download_file_sequential(client, url, dest, show_progress).await
+        }
+    }
+}
+
+async fn download_file_sequential(
+    client: &AppleClient,
+    url: &str,
+    dest: &Path,
+    show_progress: bool,
+) -> Result<(), ClientError> {
     let existing_size = if dest.exists() {
         tokio::fs::metadata(dest)
             .await
@@ -190,18 +225,35 @@ pub async fn download_file(
         tracing::info!(existing_size, "resuming download");
     }
 
-    let resp = req.send().await?;
+    let resp = req.header("Accept-Encoding", "identity").send().await?;
 
     if resp.status() == reqwest::StatusCode::RANGE_NOT_SATISFIABLE {
         tracing::info!("file already fully downloaded");
         return Ok(());
     }
 
-    let total_size = resp.content_length().map(|cl| cl + existing_size);
+    let status = resp.status();
+    let resumed = existing_size > 0 && status == reqwest::StatusCode::PARTIAL_CONTENT;
+    let restart = existing_size > 0 && status == reqwest::StatusCode::OK;
+    if existing_size > 0 && restart {
+        tracing::warn!("server ignored range request, restarting download");
+    } else if existing_size > 0 && !resumed {
+        return Err(unexpected_download_response(&resp, "resume download"));
+    } else if existing_size == 0 && !status.is_success() {
+        return Err(unexpected_download_response(&resp, "download"));
+    }
+    if looks_like_error_body(&resp) {
+        return Err(unexpected_download_response(&resp, "download"));
+    }
+
+    let starting_position = if resumed { existing_size } else { 0 };
+    let total_size = resp.content_length().map(|cl| cl + starting_position);
 
     let mut file = tokio::fs::OpenOptions::new()
         .create(true)
-        .append(true)
+        .append(resumed)
+        .write(true)
+        .truncate(!resumed)
         .open(dest)
         .await
         .map_err(|e| ClientError::UnexpectedResponse(format!("open file: {e}")))?;
@@ -216,7 +268,7 @@ pub async fn download_file(
                         .unwrap()
                         .progress_chars("=> "),
                 );
-                pb.set_position(existing_size);
+                pb.set_position(starting_position);
                 pb
             }
             None => {
@@ -236,8 +288,7 @@ pub async fn download_file(
     };
 
     let mut stream = resp.bytes_stream();
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk?;
+    while let Some(chunk) = next_download_chunk(&mut stream).await? {
         file.write_all(&chunk)
             .await
             .map_err(|e| ClientError::UnexpectedResponse(format!("write: {e}")))?;
@@ -255,6 +306,220 @@ pub async fn download_file(
     }
 
     Ok(())
+}
+
+async fn download_file_parallel(
+    client: &AppleClient,
+    url: &str,
+    dest: &Path,
+    show_progress: bool,
+    connections: usize,
+    total_size: u64,
+) -> Result<(), ClientError> {
+    let connections = connections.clamp(1, 16);
+    let part_size = total_size.div_ceil(connections as u64);
+    let part_paths: Vec<PathBuf> = (0..connections)
+        .map(|idx| dest.with_extension(format!("ipa.part{idx}")))
+        .collect();
+
+    tokio::fs::remove_file(dest).await.ok();
+    for path in &part_paths {
+        tokio::fs::remove_file(path).await.ok();
+    }
+
+    let pb = if show_progress {
+        let pb = ProgressBar::new(total_size);
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("{msg} [{bar:40}] {bytes}/{total_bytes} {binary_bytes_per_sec} ({eta})")
+                .unwrap()
+                .progress_chars("=> "),
+        );
+        pb.set_message(format!("Downloading ({connections} connections)"));
+        Some(pb)
+    } else {
+        None
+    };
+
+    let mut tasks = FuturesUnordered::new();
+    for (idx, path) in part_paths.iter().enumerate().take(connections) {
+        let start = idx as u64 * part_size;
+        if start >= total_size {
+            continue;
+        }
+
+        let end = (start + part_size - 1).min(total_size - 1);
+        let path = path.clone();
+        let http = client.http().clone();
+        let url = url.to_string();
+        let pb = pb.clone();
+        tasks.push(tokio::spawn(async move {
+            download_range(http, url, path, start, end, pb).await
+        }));
+    }
+
+    while let Some(result) = tasks.next().await {
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => {
+                cleanup_parts(&part_paths).await;
+                if let Some(pb) = pb {
+                    pb.abandon_with_message("Download failed");
+                }
+                return Err(err);
+            }
+            Err(err) => {
+                cleanup_parts(&part_paths).await;
+                if let Some(pb) = pb {
+                    pb.abandon_with_message("Download failed");
+                }
+                return Err(ClientError::UnexpectedResponse(format!(
+                    "download task failed: {err}"
+                )));
+            }
+        }
+    }
+
+    let mut dest_file = tokio::fs::File::create(dest)
+        .await
+        .map_err(|e| ClientError::UnexpectedResponse(format!("create destination: {e}")))?;
+    for path in &part_paths {
+        let mut part = tokio::fs::File::open(path)
+            .await
+            .map_err(|e| ClientError::UnexpectedResponse(format!("open part: {e}")))?;
+        tokio::io::copy(&mut part, &mut dest_file)
+            .await
+            .map_err(|e| ClientError::UnexpectedResponse(format!("copy part: {e}")))?;
+    }
+    dest_file
+        .flush()
+        .await
+        .map_err(|e| ClientError::UnexpectedResponse(format!("flush destination: {e}")))?;
+    cleanup_parts(&part_paths).await;
+
+    if let Some(pb) = pb {
+        pb.finish_with_message("Download complete");
+    }
+
+    Ok(())
+}
+
+async fn download_range(
+    http: reqwest::Client,
+    url: String,
+    path: PathBuf,
+    start: u64,
+    end: u64,
+    pb: Option<ProgressBar>,
+) -> Result<(), ClientError> {
+    let resp = http
+        .get(&url)
+        .header("Accept-Encoding", "identity")
+        .header("Range", format!("bytes={start}-{end}"))
+        .send()
+        .await?;
+
+    if resp.status() != reqwest::StatusCode::PARTIAL_CONTENT || looks_like_error_body(&resp) {
+        return Err(unexpected_download_response(&resp, "range download"));
+    }
+
+    let mut file = tokio::fs::File::create(&path)
+        .await
+        .map_err(|e| ClientError::UnexpectedResponse(format!("create part: {e}")))?;
+    let mut stream = resp.bytes_stream();
+    let mut downloaded = 0u64;
+    let expected = end - start + 1;
+
+    while let Some(chunk) = next_download_chunk(&mut stream).await? {
+        file.write_all(&chunk)
+            .await
+            .map_err(|e| ClientError::UnexpectedResponse(format!("write part: {e}")))?;
+        downloaded += chunk.len() as u64;
+        if let Some(ref pb) = pb {
+            pb.inc(chunk.len() as u64);
+        }
+    }
+
+    file.flush()
+        .await
+        .map_err(|e| ClientError::UnexpectedResponse(format!("flush part: {e}")))?;
+
+    if downloaded != expected {
+        return Err(ClientError::UnexpectedResponse(format!(
+            "short range download: expected {expected} bytes, got {downloaded}"
+        )));
+    }
+
+    Ok(())
+}
+
+async fn fetch_download_size(client: &AppleClient, url: &str) -> Result<u64, ClientError> {
+    let resp = client
+        .http()
+        .get(url)
+        .header("Accept-Encoding", "identity")
+        .header("Range", "bytes=0-0")
+        .send()
+        .await?;
+
+    if resp.status() != reqwest::StatusCode::PARTIAL_CONTENT || looks_like_error_body(&resp) {
+        return Err(unexpected_download_response(&resp, "download size probe"));
+    }
+
+    resp.headers()
+        .get("content-range")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.rsplit('/').next())
+        .and_then(|s| s.parse::<u64>().ok())
+        .ok_or_else(|| ClientError::UnexpectedResponse("missing Content-Range total".into()))
+}
+
+async fn next_download_chunk(
+    stream: &mut (impl StreamExt<Item = Result<bytes::Bytes, reqwest::Error>> + Unpin),
+) -> Result<Option<bytes::Bytes>, ClientError> {
+    tokio::time::timeout(DOWNLOAD_IDLE_TIMEOUT, stream.next())
+        .await
+        .map_err(|_| {
+            ClientError::UnexpectedResponse(format!(
+                "download stalled for {} seconds",
+                DOWNLOAD_IDLE_TIMEOUT.as_secs()
+            ))
+        })?
+        .transpose()
+        .map_err(ClientError::Http)
+}
+
+fn unexpected_download_response(resp: &reqwest::Response, context: &str) -> ClientError {
+    ClientError::UnexpectedResponse(format!(
+        "{context}: HTTP {}, content-type {}, content-length {}",
+        resp.status(),
+        resp.headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("<missing>"),
+        resp.content_length()
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "<missing>".into())
+    ))
+}
+
+fn looks_like_error_body(resp: &reqwest::Response) -> bool {
+    resp.headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|content_type| {
+            let content_type = content_type.to_ascii_lowercase();
+            content_type.starts_with("text/")
+                || content_type.contains("html")
+                || content_type.contains("json")
+        })
+        .unwrap_or(false)
+}
+
+async fn cleanup_parts(paths: &[PathBuf]) {
+    for path in paths {
+        tokio::fs::remove_file(path).await.ok();
+    }
 }
 
 fn download_url(account: &Account, guid: &str) -> String {

--- a/crates/ipatool-core/src/api/purchase.rs
+++ b/crates/ipatool-core/src/api/purchase.rs
@@ -108,9 +108,8 @@ async fn try_purchase(
     let resp_body = resp.bytes().await?;
     tracing::debug!(
         len = resp_body.len(),
-        preview = %String::from_utf8_lossy(&resp_body[..resp_body.len().min(500)]),
         pricing = pricing_parameters,
-        "purchase response body"
+        "purchase response body received"
     );
     let dict: HashMap<String, plist::Value> =
         crate::client::plist_xml::parse_plist_response(&resp_body)?;

--- a/crates/ipatool-core/src/api/reauth.rs
+++ b/crates/ipatool-core/src/api/reauth.rs
@@ -9,7 +9,11 @@ pub async fn reauthenticate(
     let password = account
         .password
         .as_deref()
-        .ok_or_else(|| ClientError::UnexpectedResponse("no stored password for re-auth".into()))?;
+        .ok_or_else(|| {
+            ClientError::UnexpectedResponse(
+                "stored credentials do not include a password; run `ipatool auth login` to refresh the session".into(),
+            )
+        })?;
 
     let auth_url = super::bag::fetch_auth_endpoint(client).await?;
 

--- a/crates/ipatool-core/src/client/cookie_jar.rs
+++ b/crates/ipatool-core/src/client/cookie_jar.rs
@@ -28,6 +28,15 @@ pub fn new_cookie_store(path: Option<&Path>) -> Result<Arc<CookieStoreMutex>, Cl
 pub fn save_cookie_store(store: &CookieStoreMutex, path: &Path) -> Result<(), ClientError> {
     let mut file = std::fs::File::create(path)
         .map_err(|e| ClientError::UnexpectedResponse(format!("cookie file create: {e}")))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| ClientError::UnexpectedResponse(format!("cookie permissions: {e}")))?;
+    }
+
     let guard = store.lock().unwrap();
     #[allow(deprecated)]
     guard

--- a/crates/ipatool-core/src/model/account.rs
+++ b/crates/ipatool-core/src/model/account.rs
@@ -8,6 +8,49 @@ pub struct Account {
     pub name: String,
     pub store_front: String,
     pub pod: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip)]
     pub password: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Account;
+
+    fn test_account() -> Account {
+        Account {
+            email: "user@example.com".to_string(),
+            password_token: "token".to_string(),
+            directory_services_id: "12345".to_string(),
+            name: "Test User".to_string(),
+            store_front: "143441-1,29".to_string(),
+            pod: Some("31".to_string()),
+            password: Some("super-secret".to_string()),
+        }
+    }
+
+    #[test]
+    fn skips_password_when_serializing() {
+        let json = serde_json::to_string(&test_account()).unwrap();
+
+        assert!(!json.contains(r#""password":"#));
+        assert!(!json.contains("super-secret"));
+    }
+
+    #[test]
+    fn ignores_password_when_deserializing() {
+        let json = r#"{
+            "email": "user@example.com",
+            "password_token": "token",
+            "directory_services_id": "12345",
+            "name": "Test User",
+            "store_front": "143441-1,29",
+            "pod": "31",
+            "password": "super-secret"
+        }"#;
+
+        let account: Account = serde_json::from_str(json).unwrap();
+
+        assert_eq!(account.email, "user@example.com");
+        assert!(account.password.is_none());
+    }
 }


### PR DESCRIPTION
## Summary
- Stop serializing/deserializing the raw Apple ID password in stored account credentials.
- Sanitize account JSON output so `auth info --format json` and login JSON output no longer expose stored secrets.
- Narrow verbose logging to ipatool crates and remove App Store response body previews from debug logs.
- Save the ipatool data directory and cookie file with private Unix permissions.
- Update README guidance to prefer interactive login over command-line password flags.
- Validate IPA download HTTP status/content type before writing data, fail stalled downloads, fix ignored range-resume corruption, and add ranged parallel CLI downloads via `--connections`.

## Why
The CLI handles Apple ID credentials and App Store session data. The previous behavior could persist the raw Apple ID password, expose it in JSON output, and enable dependency debug logs that include cookie details.

The download path also accepted any HTTP response as IPA bytes, so CDN errors or HTML responses could be written to `.ipa.tmp` and only fail later during patching. Single-connection downloads can also be very slow on some Apple CDN paths, so the CLI now supports modest parallel ranged downloads.

## Validation
- `cargo fmt --all --check`
- `cargo test --workspace --locked`
- `cargo check --workspace --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo build --release --locked`
- `git diff --check`