### PR TITLE
fix: windows input duplication

### DIFF
--- a/crates/ipatool-cli/src/commands/auth.rs
+++ b/crates/ipatool-cli/src/commands/auth.rs
@@ -6,6 +6,7 @@ use ipatool_core::credential;
 use ipatool_core::error::{ClientError, StoreError};
 
 use crate::output::{OutputFormat, print_account};
+use crate::read_password;
 
 pub async fn login(
     client: &mut AppleClient,
@@ -21,7 +22,7 @@ pub async fn login(
             if non_interactive {
                 bail!("password required in non-interactive mode");
             }
-            rpassword::prompt_password("Password: ").context("failed to read password")?
+            read_password::prompt_password("Password: ").context("failed to read password")?
         }
     };
 
@@ -39,7 +40,7 @@ pub async fn login(
             eprintln!(
                 "Apple rejected the login. If Apple is showing a two-factor code, enter it now; otherwise press Enter and check your password."
             );
-            let auth_code = rpassword::prompt_password("Two-factor code (optional): ")
+            let auth_code = read_password::prompt_password("Two-factor code (optional): ")
                 .context("failed to read 2FA code")?;
             let auth_code = auth_code.trim();
             if auth_code.is_empty() {

--- a/crates/ipatool-cli/src/main.rs
+++ b/crates/ipatool-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod output;
+mod read_password;
 mod tui;
 
 use std::path::PathBuf;

--- a/crates/ipatool-cli/src/read_password.rs
+++ b/crates/ipatool-cli/src/read_password.rs
@@ -9,10 +9,8 @@ pub fn prompt_password(prompt: &str) -> io::Result<String> {
 
 #[cfg(windows)]
 pub fn prompt_password(prompt: &str) -> io::Result<String> {
-    use std::io::Write;
-
-    write!(io::stderr(), "{prompt}")?;
-    io::stderr().flush()?;
+    let mut output = PromptOutput::open();
+    output.write(prompt)?;
 
     let input = ConsoleInput::open()?;
 
@@ -63,7 +61,7 @@ pub fn prompt_password(prompt: &str) -> io::Result<String> {
         data.pop();
     }
 
-    writeln!(io::stderr())?;
+    output.write("\n")?;
 
     let password = String::from_utf16(&data)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid UTF-16 input"))?;
@@ -73,6 +71,55 @@ pub fn prompt_password(prompt: &str) -> io::Result<String> {
 
 #[cfg(windows)]
 type Handle = *mut std::ffi::c_void;
+
+#[cfg(windows)]
+enum PromptOutput {
+    Console(Handle),
+    Stderr,
+}
+
+#[cfg(windows)]
+impl PromptOutput {
+    fn open() -> Self {
+        match open_console_device("CONOUT$") {
+            Ok(handle) => Self::Console(handle),
+            Err(_) => Self::Stderr,
+        }
+    }
+
+    fn write(&mut self, text: &str) -> io::Result<()> {
+        match self {
+            Self::Console(handle) => {
+                if write_console(*handle, text).is_ok() {
+                    return Ok(());
+                }
+
+                unsafe {
+                    CloseHandle(*handle);
+                }
+                *self = Self::Stderr;
+                self.write(text)
+            }
+            Self::Stderr => {
+                use std::io::Write;
+
+                write!(io::stderr(), "{text}")?;
+                io::stderr().flush()
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for PromptOutput {
+    fn drop(&mut self) {
+        if let Self::Console(handle) = self {
+            unsafe {
+                CloseHandle(*handle);
+            }
+        }
+    }
+}
 
 #[cfg(windows)]
 struct ConsoleInput {
@@ -96,21 +143,7 @@ impl ConsoleInput {
             }
         }
 
-        let conin = "CONIN$\0".encode_utf16().collect::<Vec<u16>>();
-        let handle = unsafe {
-            CreateFileW(
-                conin.as_ptr(),
-                GENERIC_READ | GENERIC_WRITE,
-                FILE_SHARE_READ | FILE_SHARE_WRITE,
-                ptr::null_mut(),
-                OPEN_EXISTING,
-                0,
-                ptr::null_mut(),
-            )
-        };
-        if is_invalid_handle(handle) {
-            return Err(io::Error::last_os_error());
-        }
+        let handle = open_console_device("CONIN$")?;
 
         let mut original_mode = 0;
         if unsafe { GetConsoleMode(handle, &mut original_mode) } == 0 {
@@ -144,6 +177,51 @@ impl Drop for ConsoleInput {
 #[cfg(windows)]
 fn is_invalid_handle(handle: Handle) -> bool {
     handle.is_null() || handle as isize == -1
+}
+
+#[cfg(windows)]
+fn open_console_device(name: &str) -> io::Result<Handle> {
+    let path = format!("{name}\0").encode_utf16().collect::<Vec<u16>>();
+    let handle = unsafe {
+        CreateFileW(
+            path.as_ptr(),
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            ptr::null_mut(),
+            OPEN_EXISTING,
+            0,
+            ptr::null_mut(),
+        )
+    };
+    if is_invalid_handle(handle) {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(handle)
+}
+
+#[cfg(windows)]
+fn write_console(handle: Handle, text: &str) -> io::Result<()> {
+    let data = text.encode_utf16().collect::<Vec<u16>>();
+    if data.is_empty() {
+        return Ok(());
+    }
+
+    let mut chars_written: u32 = 0;
+    let result = unsafe {
+        WriteConsoleW(
+            handle,
+            data.as_ptr(),
+            data.len() as u32,
+            &mut chars_written,
+            ptr::null_mut(),
+        )
+    };
+    if result == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(())
 }
 
 #[cfg(windows)]
@@ -186,5 +264,12 @@ unsafe extern "system" {
         dwFlagsAndAttributes: u32,
         hTemplateFile: Handle,
     ) -> Handle;
+    fn WriteConsoleW(
+        hConsoleOutput: Handle,
+        lpBuffer: *const u16,
+        nNumberOfCharsToWrite: u32,
+        lpNumberOfCharsWritten: *mut u32,
+        lpReserved: *mut std::ffi::c_void,
+    ) -> i32;
     fn CloseHandle(hObject: Handle) -> i32;
 }

--- a/crates/ipatool-cli/src/read_password.rs
+++ b/crates/ipatool-cli/src/read_password.rs
@@ -35,9 +35,11 @@ pub fn prompt_password(prompt: &str) -> io::Result<String> {
         };
 
         if result == 0 {
+            output.write("\n").ok();
             return Err(io::Error::last_os_error());
         }
         if chars_read == 0 {
+            output.write("\n").ok();
             return Err(io::Error::new(
                 io::ErrorKind::UnexpectedEof,
                 "unexpected end of console input",
@@ -81,7 +83,7 @@ enum PromptOutput {
 #[cfg(windows)]
 impl PromptOutput {
     fn open() -> Self {
-        match open_console_device("CONOUT$") {
+        match open_console_device("CONOUT$", GENERIC_WRITE) {
             Ok(handle) => Self::Console(handle),
             Err(_) => Self::Stderr,
         }
@@ -143,7 +145,7 @@ impl ConsoleInput {
             }
         }
 
-        let handle = open_console_device("CONIN$")?;
+        let handle = open_console_device("CONIN$", GENERIC_READ)?;
 
         let mut original_mode = 0;
         if unsafe { GetConsoleMode(handle, &mut original_mode) } == 0 {
@@ -180,12 +182,12 @@ fn is_invalid_handle(handle: Handle) -> bool {
 }
 
 #[cfg(windows)]
-fn open_console_device(name: &str) -> io::Result<Handle> {
+fn open_console_device(name: &str, access: u32) -> io::Result<Handle> {
     let path = format!("{name}\0").encode_utf16().collect::<Vec<u16>>();
     let handle = unsafe {
         CreateFileW(
             path.as_ptr(),
-            GENERIC_READ | GENERIC_WRITE,
+            access,
             FILE_SHARE_READ | FILE_SHARE_WRITE,
             ptr::null_mut(),
             OPEN_EXISTING,

--- a/crates/ipatool-cli/src/read_password.rs
+++ b/crates/ipatool-cli/src/read_password.rs
@@ -1,0 +1,190 @@
+use std::io;
+#[cfg(windows)]
+use std::ptr;
+
+#[cfg(not(windows))]
+pub fn prompt_password(prompt: &str) -> io::Result<String> {
+    rpassword::prompt_password(prompt)
+}
+
+#[cfg(windows)]
+pub fn prompt_password(prompt: &str) -> io::Result<String> {
+    use std::io::Write;
+
+    write!(io::stderr(), "{prompt}")?;
+    io::stderr().flush()?;
+
+    let input = ConsoleInput::open()?;
+
+    let new_mode =
+        (input.original_mode | ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT) & !ENABLE_ECHO_INPUT;
+    if unsafe { SetConsoleMode(input.handle, new_mode) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let mut data = Vec::new();
+    loop {
+        let mut buf = [0u16; 512];
+        let mut chars_read: u32 = 0;
+        let result = unsafe {
+            ReadConsoleW(
+                input.handle,
+                buf.as_mut_ptr() as *mut _,
+                buf.len() as u32,
+                &mut chars_read,
+                ptr::null_mut(),
+            )
+        };
+
+        if result == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if chars_read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "unexpected end of console input",
+            ));
+        }
+
+        let chunk = &buf[..chars_read as usize];
+        data.extend_from_slice(chunk);
+        if chunk
+            .last()
+            .is_some_and(|c| *c == b'\n' as u16 || *c == b'\r' as u16)
+        {
+            break;
+        }
+    }
+
+    while data
+        .last()
+        .is_some_and(|c| *c == b'\n' as u16 || *c == b'\r' as u16)
+    {
+        data.pop();
+    }
+
+    writeln!(io::stderr())?;
+
+    let password = String::from_utf16(&data)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid UTF-16 input"))?;
+
+    Ok(password)
+}
+
+#[cfg(windows)]
+type Handle = *mut std::ffi::c_void;
+
+#[cfg(windows)]
+struct ConsoleInput {
+    handle: Handle,
+    original_mode: u32,
+    owned: bool,
+}
+
+#[cfg(windows)]
+impl ConsoleInput {
+    fn open() -> io::Result<Self> {
+        let std_handle = unsafe { GetStdHandle(STD_INPUT_HANDLE) };
+        if !is_invalid_handle(std_handle) {
+            let mut original_mode = 0;
+            if unsafe { GetConsoleMode(std_handle, &mut original_mode) } != 0 {
+                return Ok(Self {
+                    handle: std_handle,
+                    original_mode,
+                    owned: false,
+                });
+            }
+        }
+
+        let conin = "CONIN$\0".encode_utf16().collect::<Vec<u16>>();
+        let handle = unsafe {
+            CreateFileW(
+                conin.as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                ptr::null_mut(),
+                OPEN_EXISTING,
+                0,
+                ptr::null_mut(),
+            )
+        };
+        if is_invalid_handle(handle) {
+            return Err(io::Error::last_os_error());
+        }
+
+        let mut original_mode = 0;
+        if unsafe { GetConsoleMode(handle, &mut original_mode) } == 0 {
+            let err = io::Error::last_os_error();
+            unsafe {
+                CloseHandle(handle);
+            }
+            return Err(err);
+        }
+
+        Ok(Self {
+            handle,
+            original_mode,
+            owned: true,
+        })
+    }
+}
+
+#[cfg(windows)]
+impl Drop for ConsoleInput {
+    fn drop(&mut self) {
+        unsafe {
+            SetConsoleMode(self.handle, self.original_mode);
+            if self.owned {
+                CloseHandle(self.handle);
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+fn is_invalid_handle(handle: Handle) -> bool {
+    handle.is_null() || handle as isize == -1
+}
+
+#[cfg(windows)]
+const STD_INPUT_HANDLE: u32 = 0xFFFFFFF6u32;
+#[cfg(windows)]
+const ENABLE_PROCESSED_INPUT: u32 = 0x0001;
+#[cfg(windows)]
+const ENABLE_LINE_INPUT: u32 = 0x0002;
+#[cfg(windows)]
+const ENABLE_ECHO_INPUT: u32 = 0x0004;
+#[cfg(windows)]
+const GENERIC_READ: u32 = 0x80000000;
+#[cfg(windows)]
+const GENERIC_WRITE: u32 = 0x40000000;
+#[cfg(windows)]
+const FILE_SHARE_READ: u32 = 0x00000001;
+#[cfg(windows)]
+const FILE_SHARE_WRITE: u32 = 0x00000002;
+#[cfg(windows)]
+const OPEN_EXISTING: u32 = 3;
+
+#[cfg(windows)]
+unsafe extern "system" {
+    fn GetStdHandle(nStdHandle: u32) -> Handle;
+    fn GetConsoleMode(hConsoleHandle: Handle, lpMode: *mut u32) -> i32;
+    fn SetConsoleMode(hConsoleHandle: Handle, dwMode: u32) -> i32;
+    fn ReadConsoleW(
+        hConsoleInput: Handle,
+        lpBuffer: *mut u16,
+        nNumberOfCharsToRead: u32,
+        lpNumberOfCharsRead: *mut u32,
+        pInputControl: *mut std::ffi::c_void,
+    ) -> i32;
+    fn CreateFileW(
+        lpFileName: *const u16,
+        dwDesiredAccess: u32,
+        dwShareMode: u32,
+        lpSecurityAttributes: *mut std::ffi::c_void,
+        dwCreationDisposition: u32,
+        dwFlagsAndAttributes: u32,
+        hTemplateFile: Handle,
+    ) -> Handle;
+    fn CloseHandle(hObject: Handle) -> i32;
+}

--- a/crates/ipatool-cli/src/tui/handler.rs
+++ b/crates/ipatool-cli/src/tui/handler.rs
@@ -1,10 +1,14 @@
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use tui_input::backend::crossterm::EventHandler;
 
 use super::action::Action;
 use super::app::{ActiveTab, App_, InputMode};
 
 pub fn handle_key(app: &mut App_, key: KeyEvent) {
+    if key.kind == KeyEventKind::Release {
+        return;
+    }
+
     if let InputMode::Popup(_) = &app.input_mode {
         match key.code {
             KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') => {
@@ -261,5 +265,98 @@ fn handle_login_auth_code(app: &mut App_, key: KeyEvent) {
             app.login_auth_code
                 .handle_event(&crossterm::event::Event::Key(key));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+    use ratatui::widgets::{ListState, TableState};
+    use tokio::sync::mpsc::{self, UnboundedReceiver};
+    use tokio::sync::{Mutex, Semaphore};
+    use tui_input::Input;
+
+    use ipatool_core::client::AppleClient;
+    use ipatool_core::model::Platform;
+
+    use super::*;
+    use crate::tui::app::{ActiveTab, App_, InputMode};
+
+    fn test_app_with_rx() -> (App_, UnboundedReceiver<Action>) {
+        let (action_tx, action_rx) = mpsc::unbounded_channel();
+        let client = AppleClient::new("test-guid".to_string(), None).unwrap();
+
+        let app = App_ {
+            active_tab: ActiveTab::Search,
+            input_mode: InputMode::Normal,
+            should_quit: false,
+            action_tx,
+            search_input: Input::default(),
+            search_results: Vec::new(),
+            search_table_state: TableState::default(),
+            search_platform: Platform::IPhone,
+            search_country: "US".to_string(),
+            is_loading: false,
+            selected_detail: None,
+            downloads: Vec::new(),
+            download_list_state: ListState::default(),
+            download_semaphore: Arc::new(Semaphore::new(3)),
+            next_download_id: 0,
+            account: None,
+            login_email: Input::default(),
+            login_password: String::new(),
+            login_auth_code: Input::default(),
+            login_error: None,
+            client: Arc::new(Mutex::new(client)),
+            status_message: String::new(),
+        };
+
+        (app, action_rx)
+    }
+
+    fn test_app() -> App_ {
+        test_app_with_rx().0
+    }
+
+    fn key(code: KeyCode, kind: KeyEventKind) -> KeyEvent {
+        KeyEvent::new_with_kind(code, KeyModifiers::NONE, kind)
+    }
+
+    #[test]
+    fn ignores_key_release_events() {
+        let mut app = test_app();
+        app.input_mode = InputMode::LoginPassword;
+
+        handle_key(&mut app, key(KeyCode::Char('p'), KeyEventKind::Press));
+        handle_key(&mut app, key(KeyCode::Char('p'), KeyEventKind::Release));
+
+        assert_eq!(app.login_password, "p");
+    }
+
+    #[test]
+    fn preserves_key_repeat_events() {
+        let mut app = test_app();
+        app.input_mode = InputMode::LoginPassword;
+
+        handle_key(&mut app, key(KeyCode::Char('p'), KeyEventKind::Press));
+        handle_key(&mut app, key(KeyCode::Char('p'), KeyEventKind::Repeat));
+
+        assert_eq!(app.login_password, "pp");
+    }
+
+    #[test]
+    fn ignores_key_release_events_for_navigation() {
+        let (mut app, mut action_rx) = test_app_with_rx();
+
+        handle_key(&mut app, key(KeyCode::Tab, KeyEventKind::Press));
+        handle_key(&mut app, key(KeyCode::Tab, KeyEventKind::Release));
+
+        match action_rx.try_recv() {
+            Ok(Action::SwitchTab(ActiveTab::Library)) => {}
+            other => panic!("expected one switch-tab action, got {other:?}"),
+        }
+        assert!(action_rx.try_recv().is_err());
     }
 }


### PR DESCRIPTION
## Summary

- add a Windows-specific CLI password reader that uses console line mode without echo
- route CLI password and optional 2FA prompts through the platform-aware reader
- ignore crossterm key release events in the TUI while preserving repeat events

## Root cause

On Windows, interactive input can surface both key press and key release events. The TUI handled both, so navigation and manually handled password input could be applied twice. The CLI prompt also relied on the current rpassword Windows path, which switches console input out of line mode and can duplicate typed characters in affected terminals.

## Validation

- cargo fmt --check
- cargo check --workspace
- cargo test --workspace
- cargo clippy --all-targets -- -D warnings
- git diff --check
- rustc --edition=2024 --crate-type lib --target x86_64-pc-windows-msvc --emit=metadata crates/ipatool-cli/src/read_password.rs -o /private/tmp/read_password.rmeta

Full local `cargo check -p ipatool --target x86_64-pc-windows-msvc` is blocked on this macOS host by the dependency C toolchain for `ring` before it reaches project code.

Fixes #8
