### PR TITLE
fix(core): keep POST body across auth pod redirects

### DIFF
--- a/crates/ipatool-core/src/api/auth.rs
+++ b/crates/ipatool-core/src/api/auth.rs
@@ -46,7 +46,7 @@ pub async fn login(
         let status = resp.status();
         tracing::debug!(%status, "auth response status");
 
-        if status == reqwest::StatusCode::FOUND
+        if status.is_redirection()
             && let Some(location) = resp.headers().get("location")
         {
             redirects += 1;
@@ -60,7 +60,8 @@ pub async fn login(
                 .to_str()
                 .map_err(|_| ClientError::MissingHeader("location (invalid)".into()))?;
             tracing::debug!(new_url, "following redirect");
-            current_url = Url::parse(new_url)
+            current_url = current_url
+                .join(new_url)
                 .map_err(|e| ClientError::UnexpectedResponse(format!("redirect URL: {e}")))?;
             continue;
         }

--- a/crates/ipatool-core/src/client/mod.rs
+++ b/crates/ipatool-core/src/client/mod.rs
@@ -12,8 +12,15 @@ use crate::model::Account;
 const USER_AGENT: &str =
     "Configurator/2.17 (Macintosh; OS X 15.2; 24C5089c) AppleWebKit/0620.1.16.11.6";
 
-const MZFINANCE_AUTH_URL: &str =
-    "https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/authenticate";
+/// Auth endpoints 302-redirect POSTs to account-specific pod hosts
+/// (e.g. p14-buy.itunes.apple.com); auto-following would turn the POST into a
+/// bodyless GET, so those redirects must surface to api::auth::login, which
+/// re-sends the full request. Matched by path so it covers the bare host, pod
+/// hosts, and the native /fast/ endpoint, with or without a trailing slash.
+fn is_auth_endpoint(url: &reqwest::Url) -> bool {
+    let path = url.path().trim_end_matches('/');
+    path.ends_with("/wa/authenticate") || path.ends_with("/native/fast")
+}
 
 pub struct AppleClient {
     http: reqwest::Client,
@@ -30,10 +37,7 @@ impl AppleClient {
             .user_agent(USER_AGENT)
             .cookie_provider(cookie_store.clone())
             .redirect(reqwest::redirect::Policy::custom(|attempt| {
-                let from_auth = attempt
-                    .previous()
-                    .last()
-                    .is_some_and(|u| u.as_str() == MZFINANCE_AUTH_URL);
+                let from_auth = attempt.previous().last().is_some_and(is_auth_endpoint);
                 if from_auth {
                     attempt.stop()
                 } else {
@@ -68,5 +72,44 @@ impl AppleClient {
 
     pub fn save_cookies(&self, path: &Path) -> Result<(), ClientError> {
         cookie_jar::save_cookie_store(&self.cookie_store, path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_auth_endpoint;
+
+    fn url(s: &str) -> reqwest::Url {
+        reqwest::Url::parse(s).unwrap()
+    }
+
+    #[test]
+    fn auth_endpoint_matches_with_and_without_trailing_slash() {
+        assert!(is_auth_endpoint(&url(
+            "https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/authenticate"
+        )));
+        assert!(is_auth_endpoint(&url(
+            "https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/authenticate/"
+        )));
+    }
+
+    #[test]
+    fn auth_endpoint_matches_pod_hosts_and_native_fast() {
+        assert!(is_auth_endpoint(&url(
+            "https://p14-buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/authenticate/"
+        )));
+        assert!(is_auth_endpoint(&url(
+            "https://auth.itunes.apple.com/auth/v1/native/fast/"
+        )));
+    }
+
+    #[test]
+    fn non_auth_endpoints_do_not_match() {
+        assert!(!is_auth_endpoint(&url(
+            "https://p14-buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct?guid=X"
+        )));
+        assert!(!is_auth_endpoint(&url(
+            "https://init.itunes.apple.com/bag.xml?ix=5"
+        )));
     }
 }


### PR DESCRIPTION
## Problem

`auth login` failed with `unexpected response: empty response (HTTP 404 Not Found)` right after entering a correct password and 2FA code.

Fixes #12.

## Root cause

On a successful second-factor attempt, `buy.itunes.apple.com` answers the authenticate POST with a 302 to the account's pod host (e.g. `p14-buy.itunes.apple.com`), expecting the client to re-send the request there.

The custom reqwest redirect policy in `client/mod.rs` was supposed to surface that 302 to `api::auth::login` (which re-POSTs the plist body), but it matched the auth endpoint by **exact string** against `.../wa/authenticate` — while the URL fetched from the bag gets a trailing slash appended in `bag.rs`. The match never fired, reqwest auto-followed the 302, and per HTTP semantics the POST became a bodyless GET, which the pod host answers with an empty 404.

## Fix

- Match auth endpoints by path (`/wa/authenticate`, `/native/fast`), ignoring the trailing slash — this also covers pod hosts redirecting again.
- In `api::auth::login`, accept any 3xx status (not just 302) and resolve relative `Location` headers via `Url::join`.
- Unit tests for the endpoint predicate, including the regression case.

## Testing

- `make check` passes; all 36 `ipatool-core` tests pass (3 new).
- Manually verified: `ipatool auth login` with password + 2FA now follows the pod redirect, re-POSTs, and logs in successfully.