### PR TITLE
docs: fix install commands after ipatool-rs rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This rewrite adds a keyboard-driven terminal UI, structured Rust models, clearer
 ### Homebrew (macOS / Linux)
 
 ```bash
-brew install Kosthi/tap/ipatool
+brew install Kosthi/tap/ipatool-rs
 ```
 
 ### Cargo
@@ -76,19 +76,19 @@ The release also includes `cargo-dist` installer scripts that install the `ipato
 
 ```bash
 # macOS / Linux
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Kosthi/ipatool-rs/releases/latest/download/ipatool-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Kosthi/ipatool-rs/releases/latest/download/ipatool-rs-installer.sh | sh
 
 # Windows PowerShell
-powershell -ExecutionPolicy Bypass -c "irm https://github.com/Kosthi/ipatool-rs/releases/latest/download/ipatool-installer.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/Kosthi/ipatool-rs/releases/latest/download/ipatool-rs-installer.ps1 | iex"
 ```
 
 | Platform | Asset | Install |
 |----------|-------|---------|
-| Windows x64 | `ipatool-x86_64-pc-windows-msvc.zip` | Extract and place `ipatool.exe` on your `PATH`. |
-| macOS Apple Silicon | `ipatool-aarch64-apple-darwin.tar.xz` | Extract and place `ipatool` on your `PATH`. |
-| macOS Intel | `ipatool-x86_64-apple-darwin.tar.xz` | Extract and place `ipatool` on your `PATH`. |
-| Linux x64 | `ipatool-x86_64-unknown-linux-gnu.tar.xz` | Extract and place `ipatool` on your `PATH`. |
-| Linux ARM64 | `ipatool-aarch64-unknown-linux-gnu.tar.xz` | Extract and place `ipatool` on your `PATH`. |
+| Windows x64 | `ipatool-rs-x86_64-pc-windows-msvc.zip` | Extract and place `ipatool.exe` on your `PATH`. |
+| macOS Apple Silicon | `ipatool-rs-aarch64-apple-darwin.tar.xz` | Extract and place `ipatool` on your `PATH`. |
+| macOS Intel | `ipatool-rs-x86_64-apple-darwin.tar.xz` | Extract and place `ipatool` on your `PATH`. |
+| Linux x64 | `ipatool-rs-x86_64-unknown-linux-gnu.tar.xz` | Extract and place `ipatool` on your `PATH`. |
+| Linux ARM64 | `ipatool-rs-aarch64-unknown-linux-gnu.tar.xz` | Extract and place `ipatool` on your `PATH`. |
 
 Each release also includes per-asset `.sha256` files and a unified `sha256.sum`.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -58,7 +58,7 @@
 ### Homebrew（macOS / Linux）
 
 ```bash
-brew install Kosthi/tap/ipatool
+brew install Kosthi/tap/ipatool-rs
 ```
 
 ### Cargo
@@ -73,19 +73,19 @@ cargo install ipatool-rs
 
 ```bash
 # macOS / Linux
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Kosthi/ipatool-rs/releases/latest/download/ipatool-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Kosthi/ipatool-rs/releases/latest/download/ipatool-rs-installer.sh | sh
 
 # Windows PowerShell
-powershell -ExecutionPolicy Bypass -c "irm https://github.com/Kosthi/ipatool-rs/releases/latest/download/ipatool-installer.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/Kosthi/ipatool-rs/releases/latest/download/ipatool-rs-installer.ps1 | iex"
 ```
 
 | 平台 | 文件 | 安装方式 |
 |------|------|----------|
-| Windows x64 | `ipatool-x86_64-pc-windows-msvc.zip` | 解压后将 `ipatool.exe` 放入 PATH。 |
-| macOS Apple Silicon | `ipatool-aarch64-apple-darwin.tar.xz` | 解压后将 `ipatool` 放入 PATH。 |
-| macOS Intel | `ipatool-x86_64-apple-darwin.tar.xz` | 解压后将 `ipatool` 放入 PATH。 |
-| Linux x64 | `ipatool-x86_64-unknown-linux-gnu.tar.xz` | 解压后将 `ipatool` 放入 PATH。 |
-| Linux ARM64 | `ipatool-aarch64-unknown-linux-gnu.tar.xz` | 解压后将 `ipatool` 放入 PATH。 |
+| Windows x64 | `ipatool-rs-x86_64-pc-windows-msvc.zip` | 解压后将 `ipatool.exe` 放入 PATH。 |
+| macOS Apple Silicon | `ipatool-rs-aarch64-apple-darwin.tar.xz` | 解压后将 `ipatool` 放入 PATH。 |
+| macOS Intel | `ipatool-rs-x86_64-apple-darwin.tar.xz` | 解压后将 `ipatool` 放入 PATH。 |
+| Linux x64 | `ipatool-rs-x86_64-unknown-linux-gnu.tar.xz` | 解压后将 `ipatool` 放入 PATH。 |
+| Linux ARM64 | `ipatool-rs-aarch64-unknown-linux-gnu.tar.xz` | 解压后将 `ipatool` 放入 PATH。 |
 
 每个发布版本还包含各资产的 `.sha256` 校验文件和统一的 `sha256.sum`。
 


### PR DESCRIPTION
The crate was renamed ipatool -> ipatool-rs before v0.1.6, and dist derives both the Homebrew formula name and the release artifact names from the package name. The install instructions still referenced the old names, so since v0.1.6 the installer URLs 404'd and the brew command resolved to a stale ipatool.rb frozen at v0.1.5.

Point the brew command, installer script URLs, and asset table at the ipatool-rs-* names actually published in the v0.1.8 release. The binary itself is still called ipatool, so usage examples are unchanged.

The tap now carries a formula_renames.json mapping ipatool -> ipatool-rs, so existing installs migrate on upgrade.