### PR TITLE
fix(core): resend sign-in requests Apple's edge drops

### DIFF
--- a/crates/ipatool-core/src/api/auth.rs
+++ b/crates/ipatool-core/src/api/auth.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use url::Url;
 
 use crate::client::AppleClient;
+use crate::client::plist_xml::{looks_like_plist, parse_plist_response};
 use crate::error::{ClientError, StoreError};
 use crate::model::Account;
 use crate::sap::ActionSigner;
@@ -10,6 +11,15 @@ use crate::sap::ActionSigner;
 const MAX_ATTEMPTS: u32 = 4;
 const MAX_REDIRECTS: u32 = 5;
 const AUTH_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Apple's edge drops sign-in requests on its own account, answering with a
+/// contentless 204, an HTML 404, a bare 3xx carrying no `Location`, or a 5xx —
+/// none of which say anything about the credentials. The same bytes go through
+/// moments later, and which endpoint misbehaves even moves around between
+/// tries, so resending is worth more than any of it is diagnostic.
+/// See issue #17 and majd/ipatool#520.
+const MAX_SEND_TRIES: u32 = 3;
+const SEND_RETRY_DELAY: Duration = Duration::from_millis(250);
 
 /// Header carrying the SAP signature over the request body.
 const ACTION_SIGNATURE_HEADER: &str = "X-Apple-ActionSignature";
@@ -39,28 +49,21 @@ pub async fn login(
         plist::to_writer_xml(&mut body_bytes, &body)
             .map_err(|e| ClientError::UnexpectedResponse(format!("plist serialize: {e}")))?;
 
-        tracing::debug!(attempt, url = %current_url, signed = signer.is_some(), "sending auth request");
-
-        let mut request = client
-            .http()
-            .post(current_url.as_str())
-            .header("Content-Type", "application/x-apple-plist")
-            .timeout(AUTH_REQUEST_TIMEOUT);
-
         // Apple signs the exact bytes it receives, so this has to happen after
         // the body is serialized and before it is sent.
-        if let Some(signer) = signer {
-            let signature = signer.sign(&body_bytes)?;
-            request = request.header(ACTION_SIGNATURE_HEADER, encode_base64(&signature));
-        }
+        let signature = match signer {
+            Some(signer) => Some(encode_base64(&signer.sign(&body_bytes)?)),
+            None => None,
+        };
 
-        let resp = request.body(body_bytes).send().await?;
+        tracing::debug!(attempt, url = %current_url, signed = signature.is_some(), "sending auth request");
 
-        let status = resp.status();
-        tracing::debug!(%status, "auth response status");
+        let resp =
+            send_auth_request(client, &current_url, &body_bytes, signature.as_deref()).await?;
+        let status = resp.status;
 
         if status.is_redirection()
-            && let Some(location) = resp.headers().get("location")
+            && let Some(location) = resp.location.as_deref()
         {
             redirects += 1;
             if redirects > MAX_REDIRECTS {
@@ -69,12 +72,9 @@ pub async fn login(
                 ));
             }
 
-            let new_url = location
-                .to_str()
-                .map_err(|_| ClientError::MissingHeader("location (invalid)".into()))?;
-            tracing::debug!(new_url, "following redirect");
+            tracing::debug!(location, "following redirect");
             let new_url = current_url
-                .join(new_url)
+                .join(location)
                 .map_err(|e| ClientError::UnexpectedResponse(format!("redirect URL: {e}")))?;
 
             // The redirect target receives the credentials on the next pass, so
@@ -84,27 +84,7 @@ pub async fn login(
             continue;
         }
 
-        let store_front = resp
-            .headers()
-            .get("x-set-apple-store-front")
-            .and_then(|v| v.to_str().ok())
-            .map(String::from);
-
-        let pod = resp
-            .headers()
-            .get("pod")
-            .and_then(|v| v.to_str().ok())
-            .map(String::from);
-
-        let resp_body = resp.bytes().await?;
-
-        tracing::debug!(
-            len = resp_body.len(),
-            preview = %String::from_utf8_lossy(&resp_body[..resp_body.len().min(500)]),
-            "auth response body"
-        );
-
-        if resp_body.is_empty() {
+        if resp.body.is_empty() {
             // Apple's application tier drops unsigned sign-in requests with a
             // zero-length 403. Saying so beats reporting an empty response.
             if signer.is_none() && status == reqwest::StatusCode::FORBIDDEN {
@@ -118,8 +98,16 @@ pub async fn login(
             )));
         }
 
-        let dict: HashMap<String, plist::Value> =
-            crate::client::plist_xml::parse_plist_response(&resp_body)?;
+        if !looks_like_plist(&resp.body) {
+            // Without this the body reaches the plist parser and the failure
+            // surfaces as `invalid type: string "<html>"`, which says nothing.
+            return Err(ClientError::UnexpectedResponse(format!(
+                "HTTP {status}: response is not a property list: {}",
+                String::from_utf8_lossy(&resp.body[..resp.body.len().min(200)]).trim()
+            )));
+        }
+
+        let dict: HashMap<String, plist::Value> = parse_plist_response(&resp.body)?;
 
         if let Some(err) = StoreError::from_plist_dict(&dict) {
             if err.is_retryable() && attempt < MAX_ATTEMPTS {
@@ -160,17 +148,122 @@ pub async fn login(
             })
             .unwrap_or_default();
 
-        let sf = store_front.unwrap_or_default();
-
         return Ok(Account {
             email: email.to_string(),
             password_token,
             directory_services_id: ds_person_id,
             name,
-            store_front: sf,
-            pod,
+            store_front: resp.store_front.unwrap_or_default(),
+            pod: resp.pod,
             password: None,
         });
+    }
+}
+
+/// One completed sign-in exchange, read into memory so that both the
+/// dropped-request check and the caller can look at the body.
+struct AuthResponse {
+    status: reqwest::StatusCode,
+    location: Option<String>,
+    store_front: Option<String>,
+    pod: Option<String>,
+    body: Vec<u8>,
+}
+
+/// Sends the sign-in POST, resending the identical bytes while Apple answers
+/// with something that is about its own edge rather than about the account.
+async fn send_auth_request(
+    client: &AppleClient,
+    url: &Url,
+    body: &[u8],
+    signature: Option<&str>,
+) -> Result<AuthResponse, ClientError> {
+    let mut statuses: Vec<String> = Vec::new();
+    let mut send = 1u32;
+
+    loop {
+        let mut request = client
+            .http()
+            .post(url.as_str())
+            .header("Content-Type", "application/x-apple-plist")
+            .timeout(AUTH_REQUEST_TIMEOUT)
+            .body(body.to_vec());
+
+        if let Some(signature) = signature {
+            request = request.header(ACTION_SIGNATURE_HEADER, signature);
+        }
+
+        let raw = request.send().await?;
+
+        let status = raw.status();
+        let location = header(&raw, "location");
+        let store_front = header(&raw, "x-set-apple-store-front");
+        let pod = header(&raw, "pod");
+        let body = raw.bytes().await?.to_vec();
+
+        tracing::debug!(
+            send,
+            %status,
+            len = body.len(),
+            preview = %String::from_utf8_lossy(&body[..body.len().min(500)]),
+            "auth response"
+        );
+
+        if !is_dropped_request(status, location.is_some(), &body) {
+            return Ok(AuthResponse {
+                status,
+                location,
+                store_front,
+                pod,
+                body,
+            });
+        }
+
+        statuses.push(status.as_u16().to_string());
+
+        if send == MAX_SEND_TRIES {
+            return Err(ClientError::AuthEndpointUnavailable {
+                tries: MAX_SEND_TRIES,
+                statuses: statuses.join(", "),
+            });
+        }
+
+        tracing::warn!(%status, "Apple returned no store response, resending the sign-in request");
+        tokio::time::sleep(SEND_RETRY_DELAY * send).await;
+        send += 1;
+    }
+}
+
+/// Whether a response is Apple's edge dropping the request rather than an
+/// answer about the account.
+///
+/// A 3xx carrying a `Location` is a real pod redirect and the caller follows
+/// it; a bare one is not. A body that parses as a property list is a store
+/// reply whatever its status, so it is never thrown away — Apple does report
+/// real failures under a 5xx.
+fn is_dropped_request(status: reqwest::StatusCode, has_location: bool, body: &[u8]) -> bool {
+    if looks_like_plist(body) {
+        return false;
+    }
+
+    match status.as_u16() {
+        204 | 404 => true,
+        _ if status.is_server_error() => true,
+        _ if status.is_redirection() => !has_location,
+        _ => false,
+    }
+}
+
+fn header(resp: &reqwest::Response, name: &str) -> Option<String> {
+    match resp.headers().get(name)?.to_str() {
+        Ok(value) => Some(value.to_string()),
+        Err(_) => {
+            tracing::warn!(
+                header = name,
+                "response header is not valid UTF-8, ignoring"
+            );
+            None
+        }
     }
 }
 
@@ -188,4 +281,76 @@ fn build_auth_plist(email: &str, password: &str, guid: &str, attempt: u32) -> pl
     dict.insert("rmp".into(), plist::Value::String("0".into()));
     dict.insert("why".into(), plist::Value::String("signIn".into()));
     dict
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::StatusCode;
+
+    const STORE_REPLY: &[u8] =
+        br#"<plist version="1.0"><dict><key>failureType</key><string>5002</string></dict></plist>"#;
+
+    /// What issue #17 hit: a 301 with an HTML body and no `Location`.
+    const EDGE_HTML: &[u8] = b"<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body>\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>Apple</center>\r\n</body>\r\n</html>\r\n";
+
+    #[test]
+    fn resends_a_bare_redirect() {
+        assert!(is_dropped_request(
+            StatusCode::MOVED_PERMANENTLY,
+            false,
+            EDGE_HTML
+        ));
+    }
+
+    #[test]
+    fn keeps_a_pod_redirect_for_the_caller_to_follow() {
+        assert!(!is_dropped_request(StatusCode::FOUND, true, b""));
+    }
+
+    #[test]
+    fn resends_contentless_and_not_found_replies() {
+        assert!(is_dropped_request(StatusCode::NO_CONTENT, false, b""));
+        assert!(is_dropped_request(StatusCode::NOT_FOUND, false, EDGE_HTML));
+    }
+
+    #[test]
+    fn resends_server_errors() {
+        for status in [
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::BAD_GATEWAY,
+            StatusCode::SERVICE_UNAVAILABLE,
+        ] {
+            assert!(is_dropped_request(status, false, b""), "{status}");
+        }
+    }
+
+    /// Apple reports real store failures under a 5xx, so a plist body settles
+    /// the request whatever the status says.
+    #[test]
+    fn keeps_a_store_reply_under_any_status() {
+        assert!(!is_dropped_request(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            false,
+            STORE_REPLY
+        ));
+        assert!(!is_dropped_request(StatusCode::OK, false, STORE_REPLY));
+    }
+
+    /// The zero-length 403 is the application tier's verdict on a missing
+    /// signature; resending it would only bury the diagnosis.
+    #[test]
+    fn keeps_the_unsigned_rejection() {
+        assert!(!is_dropped_request(StatusCode::FORBIDDEN, false, b""));
+    }
+
+    /// Retrying a rate limit is exactly what a rate limit is asking us not to do.
+    #[test]
+    fn keeps_rate_limits() {
+        assert!(!is_dropped_request(
+            StatusCode::TOO_MANY_REQUESTS,
+            false,
+            b""
+        ));
+    }
 }

--- a/crates/ipatool-core/src/client/mod.rs
+++ b/crates/ipatool-core/src/client/mod.rs
@@ -10,6 +10,23 @@ use crate::error::ClientError;
 use crate::guid::MachineIdentity;
 use crate::model::Account;
 
+/// Identifies this client to Apple as Apple Configurator.
+///
+/// This is not cosmetic: `init.itunes.apple.com/bag.xml` hands out a different
+/// `authenticateAccount` depending on who is asking, and the whole sign-in path
+/// — the endpoint allowlist in [`crate::api::bag`] and the SAP handshake it
+/// configures — is built around what the Configurator UA gets back.
+///
+/// | User-Agent          | `authenticateAccount`                        | `sign-sap-setup`               |
+/// |---------------------|----------------------------------------------|--------------------------------|
+/// | `Configurator/2.17` | `buy.itunes.apple.com/…/wa/authenticate`     | `…/signSapSetup/legacy`        |
+/// | `iTunes/12.12`      | `auth.itunes.apple.com/auth/v1/native`       | `…/signSapSetup` (no `legacy`) |
+/// | none                | `auth.itunes.apple.com/auth/v1/native/fast`  | `…/signSapSetup/legacy`        |
+///
+/// So changing this changes which endpoint the bag routes to, and can change
+/// the SAP setup URL along with it — possibly a different handshake variant.
+/// See issue #17, where the endpoint that turned up in a bag dump was mistaken
+/// for a client-independent migration.
 const USER_AGENT: &str =
     "Configurator/2.17 (Macintosh; OS X 15.2; 24C5089c) AppleWebKit/0620.1.16.11.6";
 

--- a/crates/ipatool-core/src/client/plist_xml.rs
+++ b/crates/ipatool-core/src/client/plist_xml.rs
@@ -45,6 +45,21 @@ pub fn normalize_plist_xml(body: &[u8]) -> Vec<u8> {
     body.to_vec()
 }
 
+/// Whether `body` carries something [`parse_plist_response`] can make sense of.
+///
+/// Apple's edge answers a request it drops with an HTML error page or with
+/// nothing at all, and those are worth telling apart from a real store reply
+/// that happens to arrive under an odd status.
+pub fn looks_like_plist(body: &[u8]) -> bool {
+    if body.starts_with(b"bplist00") {
+        return true;
+    }
+
+    // The same shapes normalize_plist_xml knows how to repair.
+    let text = String::from_utf8_lossy(body);
+    text.contains("<plist") || text.contains("<dict>") || text.contains("<key>")
+}
+
 pub fn parse_plist_response<T: serde::de::DeserializeOwned>(body: &[u8]) -> Result<T, ClientError> {
     let normalized = normalize_plist_xml(body);
     let cursor = std::io::Cursor::new(&normalized);
@@ -100,5 +115,26 @@ mod tests {
 <string>test</string>"#;
         let result: HashMap<String, String> = parse_plist_response(input).unwrap();
         assert_eq!(result.get("name"), Some(&"test".to_string()));
+    }
+
+    #[test]
+    fn store_replies_look_like_property_lists() {
+        assert!(looks_like_plist(
+            br#"<?xml version="1.0"?><plist version="1.0"><dict><key>failureType</key><string>-5000</string></dict></plist>"#
+        ));
+        assert!(looks_like_plist(
+            b"<dict><key>foo</key><string>bar</string></dict>"
+        ));
+        assert!(looks_like_plist(b"<key>foo</key><string>bar</string>"));
+        assert!(looks_like_plist(b"bplist00\x00\x01"));
+    }
+
+    /// What Apple's edge sends when it drops a sign-in request.
+    #[test]
+    fn html_error_pages_do_not() {
+        assert!(!looks_like_plist(
+            b"<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body>\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>Apple</center>\r\n</body>\r\n</html>\r\n"
+        ));
+        assert!(!looks_like_plist(b""));
     }
 }

--- a/crates/ipatool-core/src/error.rs
+++ b/crates/ipatool-core/src/error.rs
@@ -125,6 +125,14 @@ pub enum ClientError {
          See https://github.com/Kosthi/ipatool-rs/issues/15"
     )]
     SapSignatureRequired { status: u16 },
+    #[error(
+        "Apple returned no sign-in response after {tries} tries (HTTP {statuses}). None of the \
+         replies carried a store response, so this is Apple's edge dropping the request rather \
+         than a verdict on the account — the same request commonly succeeds from a different \
+         host, or a few minutes later. \
+         See https://github.com/Kosthi/ipatool-rs/issues/17"
+    )]
+    AuthEndpointUnavailable { tries: u32, statuses: String },
 }
 
 impl ClientError {


### PR DESCRIPTION
Closes the failure reported in #17.

## What is happening

Sign-in fails outright when Apple answers with something that never reached MZFinance. #17 reports a `301` carrying an HTML body and **no `Location`** header; the same report also saw a contentless `204`. majd/ipatool#520 saw both, and — the useful part — watched *which endpoint* misbehaved swap between attempts from the same host minutes apart:

```
attempt 1:  buy.itunes.apple.com/…/wa/authenticate  -> 301, HTML, no Location
            auth.itunes.apple.com/auth/v1/native/fast/  -> 204, empty
attempt 2:  buy.itunes.apple.com/…/wa/authenticate  -> 204, empty
            auth.itunes.apple.com/auth/v1/native/fast/  -> 301, HTML, no Location
```

None of those replies carry Apple's backend headers (`apple-originating-system`, `x-responding-instance`), so they are the edge dropping the request, not a verdict on the account. An unsigned probe from a working host still gets the application tier's `403` + `x-responding-instance: MZFinance:…`, and #17's own bag dump still lists `MZFinance: [authenticate]` under `sign-sap-request`. The endpoint is alive; the request is not arriving.

So this does **not** move sign-in to `auth.itunes.apple.com/auth/v1/native/fast`, which #17 proposes. Upstream tried that route (majd/ipatool#507, #514) and removed it again in majd/ipatool@abd86cb when SAP signing landed; its endpoint allowlist matches ours today.

## Why the existing retry never fired

`login()`'s loop only retries on a `StoreError` parsed out of a plist body, so a reply that is empty or is HTML fails before it is reached. A `301` with no `Location` also falls past the redirect branch straight into the plist parser — which is why the user-visible error is `invalid type: string "<html>", expected a map`.

## The change

Resend the identical signed bytes up to 3 times, 250ms apart, while the reply carries no store response.

- Signing happens once per attempt, outside the resend loop. Apple signs the exact bytes it receives and those do not change between sends.
- The `attempt` value in the body is Apple's own counter and stays put — a resend is not a new attempt.
- Retryable: `204`, `404`, `5xx`, and a `3xx` with no `Location`. **But** a body that parses as a property list settles the request whatever the status — Apple reports real failures under a `5xx`, and dispatching on status alone would swallow them.
- Deliberately not retried: `403` (the application tier rejecting an unsigned request; resending buries the `SapSignatureRequired` diagnosis) and `429` (hammering a rate limit is the one response guaranteed to make it worse).
- Exhausting all three sends reports every status seen and names the network path as the suspect, instead of leaving the reader hunting for a bug in the request.
- A non-plist body now reports its status and a snippet rather than reaching the parser.

Upstream took the same approach in majd/ipatool@30d19a6, but keys only off the status and leaves the `Location`-less `3xx` unhandled (`pkg/http/client.go` passes every `3xx` straight through) — the exact shape #17 hit.

## Testing

`is_dropped_request` and `looks_like_plist` are pure and unit-tested: bare `301`, pod `302`, `204`, HTML `404`, `5xx`, `5xx` carrying a plist, `403`, `429`, plus the HTML-vs-plist discrimination. `cargo clippy --workspace --all-targets` is clean; `cargo test --workspace` passes 109 + 7.

The resend loop itself is not covered — the workspace has no HTTP mock dev-dependency, and adding one felt out of scope here.

## Not addressed

`StoreError::RateLimited` still has no construction site, so a `429` reports as a non-plist body rather than as a rate limit. Small, but separate.